### PR TITLE
Add evaluation rules for core.Vector

### DIFF
--- a/builtin/analyzer.go
+++ b/builtin/analyzer.go
@@ -41,7 +41,10 @@ func (ba Analyzer) Analyze(env core.Env, form core.Any) (core.Expr, error) {
 		return ResolveExpr{Symbol: f}, nil
 
 	case core.Vector:
-		return VectorExpr{Vector: f}, nil
+		return VectorExpr{
+			Vector:   f,
+			Analyzer: ba,
+		}, nil
 
 	case core.Seq:
 		cnt, err := f.Count()

--- a/builtin/analyzer.go
+++ b/builtin/analyzer.go
@@ -40,6 +40,9 @@ func (ba Analyzer) Analyze(env core.Env, form core.Any) (core.Expr, error) {
 	case Symbol:
 		return ResolveExpr{Symbol: f}, nil
 
+	case core.Vector:
+		return VectorExpr{Vector: f}, nil
+
 	case core.Seq:
 		cnt, err := f.Count()
 		if err != nil {

--- a/builtin/vector.go
+++ b/builtin/vector.go
@@ -410,7 +410,7 @@ func (cs chunkedSeq) chunkedNext() (core.Seq, error) {
 }
 
 func (cs chunkedSeq) Conj(items ...core.Any) (_ core.Seq, err error) {
-	i, _ := cs.vec.Count()
+	i := cs.vec.cnt
 
 	// TODO(performance):  transient vector if len(items) > 1
 	for _, v := range items {


### PR DESCRIPTION
Vectors are currently returned with unevaluated contents.  This PR adds `VectorExpr`, which evaluates the elements of a vector when it is itself evaluated.

Follows [Clojure rules](https://clojure.org/reference/evaluation) for vectors.

⏱️ Estimated review time:  < 5 min.
✅ Merge when ready.