### PR TITLE
Improvements to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Slurp requires Go 1.14 or higher.  It can be installed using `go get`:
 go get -u github.com/spy16/slurp
 ```
 
-First-time users should visit the ["Getting Started" Tutorial](https://github.com/spy16/slurp/wiki/Getting-Started)
+First-time users should visit the ["Getting Started" Tutorial](https://github.com/spy16/slurp/wiki/Getting-Started).
 
 What can you use it for?
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ We hope that you will find Slurp to be powerful, useful and fun to use.  We look
   1. simple literals  (e.g., `\a` for `a`)
   2. special literals (e.g., `\newline`, `\tab` etc.)
   3. unicode literals (e.g., `\u00A5` for `¥` etc.)
+* Full interoperability with Go:  call native Go functions/libraries, and manipulate native Go datatypes from your language.
 * Support for macros.
 * Easy to extend. See [Extending](#extending).
 * Tiny & powerful REPL package.

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Slurp is a highly customisable, embeddable LISP toolkit for `Go` applications.
   - [Why Slurp](#why-slurp)
   - [Features](#features)
   - [Usage](#usage)
-  - [Extending](#extending)
-    - [Reader](#reader)
-    - [Evaluation](#evaluation)
+  - [Documentation](#documentation)
 
 ## Why Slurp
 
@@ -63,8 +61,6 @@ Slurp requires Go 1.14 or higher.  It can be installed using `go get`:
 go get -u github.com/spy16/slurp
 ```
 
-First-time users should visit the ["Getting Started" Tutorial](https://github.com/spy16/slurp/wiki/Getting-Started).
-
 What can you use it for?
 
 1. Embedded script engine to provide dynamic behavior without requiring re-compilation of your application ([example](./examples/simple/main.go)).
@@ -74,41 +70,11 @@ What can you use it for?
 
 Refer [./examples](./examples) for more usage examples.
 
-## Extending
+## Documentation
 
-### Reader
+In addition to the GoDocs, we maintain in-depth tutorials on the GitHub wiki.  The following
+pages are good starting points:
 
-slurp reader is inspired by Clojure reader and uses a _read table_. Reader can be extended
-to add new syntactical features by adding _reader macros_ to the _read table_. _Reader Macros_
-are implementations of `reader.Macro` function type. All syntax that reader can read are
-implemented using _Reader Macros_. Use `SetMacro()` method of `reader.Reader` to override or
-add a custom reader or dispatch macro.
-
-Reader returned by `reader.New(...)`, is configured to support following forms:
-
-* Numbers:
-  * Integers use `int64` Go representation and can be specified using decimal, binary
-    hexadecimal or radix notations. (e.g., 123, -123, 0b101011, 0xAF, 2r10100, 8r126 etc.)
-  * Floating point numbers use `float64` Go representation and can be specified using
-    decimal notation or scientific notation. (e.g.: 3.1412, -1.234, 1e-5, 2e3, 1.5e3 etc.)
-  * You can override number reader using `WithNumReader()`.
-* Characters: Characters use `rune` or `uint8` Go representation and can be written in 3 ways:
-  * Simple: `\a`, `\λ`, `\β` etc.
-  * Special: `\newline`, `\tab` etc.
-  * Unicode: `\u1267`
-* Boolean: `true` or `false` are converted to `Bool` type.
-* Nil: `nil` is represented as a zero-allocation empty struct in Go.
-* Keywords: Keywords represent symbolic data and start with `:`. (e.g., `:foo`)
-* Symbols: Symbols can be used to name a value and can contain any Unicode symbol.
-* Lists: Lists are zero or more forms contained within parentheses. (e.g., `(1 2 3)`, `(1 :hello ())`).
-
-### Evaluation
-
-Slurp uses implementation of `core.Env` as the environment for evaluating
-forms. A form is first analyzed using a `core.Analyzer` to produce `core.Expr`
-that can be evaluated against an Env. Custom implementations for all of
-these can be provided to optimise performance, customise evaluation rules
-or support additional features.
-
-A builtin Analyzer is provided which supports pure lisp forms with support
-for macros as well.
+1. [Getting Started](https://github.com/spy16/slurp/wiki/Getting-Started)
+2. [Customizing Syntax](https://github.com/spy16/slurp/wiki/Customizing-Syntax#Custom-Parsing)
+3. [Customizing Evaluation](https://github.com/spy16/slurp/wiki/Customizing-Syntax#Custom-Evaluation)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,44 @@
-# slurp
+# Slurp
+
 
 [![GoDoc](https://godoc.org/github.com/spy16/slurp?status.svg)](https://godoc.org/github.com/spy16/slurp) [![Go Report Card](https://goreportcard.com/badge/github.com/spy16/slurp)](https://goreportcard.com/report/github.com/spy16/slurp) ![Go](https://github.com/spy16/slurp/workflows/Go/badge.svg?branch=master)
 
 Slurp is a highly customisable, embeddable LISP toolkit for `Go` applications.
 
+- [Slurp](#slurp)
+  - [Why Slurp](#why-slurp)
+  - [Features](#features)
+  - [Usage](#usage)
+  - [Extending](#extending)
+    - [Reader](#reader)
+    - [Evaluation](#evaluation)
+
+## Why Slurp
+
+![I've just received word that the Emperor has dissolved the MIT computer science program permanently.](https://imgs.xkcd.com/comics/lisp_cycles.png)
+
+Slurp is for developers who want to design and embed an interpreted language inside of a Go program.
+
+Slurp provides composable building-blocks that make it easy to design a custom lisp, even if you've never written an interpreter before.  Since Slurp is written in pure Go, your new language can be embedded into any Go program by importing it — just like any other library.
+
+> **NOTE:**  Slurp is _NOT_ an implementation of a particular LISP dialect.
+> 
+> It provides pieces that can be used to build a LISP dialect or can be used as a scripting layer.
+
+Slurp is designed around three core values:
+
+1. **Simplicity:**  The library is small and has few moving parts.
+2. **Batteries Included:**  There are no external dependencies and little configuration required.
+3. **Go Interoperability:**  Slurp can call Go code and fully supports Go's concurrency features.
+
+We hope that you will find Slurp to be powerful, useful and fun to use.  We look forward to seeing what you build with it!
+
+
 ## Features
 
 * Highly customizable, safe and powerful reader/parser through
   a read table (Inspired by [Clojure](https://github.com/clojure/clojure/blob/master/src/jvm/clojure/lang/LispReader.java)) (See [Reader](#reader))
-* Built-in data types: nil, bool, string, numbers (int & float),
+* Immutable datatypes including: nil, bool, string, int & float,
   character, keyword, symbol, list, vector & map.
 * Multiple number formats supported: decimal, octal, hexadecimal,
   radix and scientific notations.
@@ -26,22 +56,20 @@ Slurp is a highly customisable, embeddable LISP toolkit for `Go` applications.
 
 ## Usage
 
-> Slurp requires Go 1.14 or higher.
+Slurp requires Go 1.14 or higher.  It can be installed using `go get`:
+
+```bash
+go get -u github.com/spy16/slurp
+```
 
 What can you use it for?
 
-1. Embedded script engine to provide dynamic behavior without requiring re-compilation
-   of your application.
-2. Business rule engine by exposing very specific & composable rule functions.
+1. Embedded script engine to provide dynamic behavior without requiring re-compilation of your application ([example](./examples/simple/main.go)).
+2. Business rule engine exposing specific, composable rules ([example](./examples/rule-engine/main.go)).
 3. To build DSLs.
-4. To build your own LISP dialect.
+4. To build your own LISP dialect ([example](https://github.com/wetware/ww)).
 
-> Please note that slurp is _NOT_ an implementation of a particular LISP dialect. It provides
-> pieces that can be used to build a LISP dialect or can be used as a scripting layer.
-
-![I've just received word that the Emperor has dissolved the MIT computer science program permanently.](https://imgs.xkcd.com/comics/lisp_cycles.png)
-
-Refer [./examples](./examples) for usage examples.
+Refer [./examples](./examples) for more usage examples.
 
 ## Extending
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Slurp requires Go 1.14 or higher.  It can be installed using `go get`:
 go get -u github.com/spy16/slurp
 ```
 
+First-time users should visit the ["Getting Started" Tutorial](https://github.com/spy16/slurp/wiki/Getting-Started)
+
 What can you use it for?
 
 1. Embedded script engine to provide dynamic behavior without requiring re-compilation of your application ([example](./examples/simple/main.go)).


### PR DESCRIPTION
@spy16 I've made a couple of changes to the README, which I now submit for your consideration — what do you think?

IMHO the current version of the README somewhat buries the lede.  In my experience, you usually want to position a product very early on, explaining who the intended audience is, and which problem it solves.  In the existing version, we immediately dive into a list of technical feature, which — while important — might leave users wondering "is this for me?"

The main change is therefore to add a 'Why Slurp' section near the top, containing a positioning statement.  It tells us _who_ Slurp is for, _why_ it exists, and _how_ it works.  This is immediately followed by the 'Features' section because if you're still reading at that point, you are convinced that Slurp is for you, and you want to ensure it meets your detailed technical requirements.

The other changes are mostly centered around convenience.  I've included a table of contents at the top of the readme, and I've also linked some of the example use-cases under 'Usage' to their relevant `main.go` files under `./examples`.  Note that I've also taken the liberty of linking use-case 4 ("build your own LISP dialect") to Wetware — I hope that's alright?

I'm probably going to add small Wiki page that contains a 'Getting Started' tutorial, and link to it from the README.
As such, please don't merge this quite yet, but please do read it over and let me know if it looks good to you! 🙂 

Change log:
- Add a 'Why Slurp' section near the top that contains a positioning statement.
- Add installation instructions under 'Usage'
- Link to examples in use-cases under 'Usage'
- Add table of contents