### PR TITLE
Add lisp unit-tests to Go's test suite

### DIFF
--- a/core/error.go
+++ b/core/error.go
@@ -8,10 +8,8 @@ import (
 // Error is returned by all slurp operations. Cause indicates the underlying
 // error type. Use errors.Is() with Cause to check for specific errors.
 type Error struct {
-	Message    string
-	Cause      error
-	Form       string
-	Begin, End Position
+	Cause   error
+	Message string
 }
 
 // With returns a clone of the error with message set to given value.
@@ -30,22 +28,17 @@ func (e Error) Unwrap() error { return e.Cause }
 
 func (e Error) Error() string {
 	if e.Cause != nil {
-		return fmt.Sprintf("%v: %s", e.Cause, e.Message)
+		return fmt.Sprintf("EvalError: %v: %s", e.Cause, e.Message)
 	}
-	return e.Message
+
+	return fmt.Sprintf("EvalError: %s", e.Message)
 }
 
-// Position represents the positional information about a value read
-// by reader.
-type Position struct {
-	File string
-	Ln   int
-	Col  int
-}
-
-func (p Position) String() string {
-	if p.File == "" {
-		p.File = "<unknown>"
+func (e Error) Format(s fmt.State, verb rune) {
+	if !s.Flag('#') {
+		fmt.Fprint(s, e.Error())
 	}
-	return fmt.Sprintf("%s:%d:%d", p.File, p.Ln, p.Col)
+
+	// TODO:  render the offending form.
+	fmt.Fprint(s, e.Error())
 }

--- a/reader/error.go
+++ b/reader/error.go
@@ -14,11 +14,6 @@ var (
 	// that more data is needed to complete the current form.
 	ErrEOF = errors.New("unexpected EOF while parsing")
 
-	// ErrUnmatchedDelimiter is returned when a reader macro encounters a closing
-	// container- delimiter without a corresponding opening delimiter (e.g. ']'
-	// but no '[').
-	ErrUnmatchedDelimiter = errors.New("unmatched delimiter")
-
 	// ErrNumberFormat is returned when a reader macro encounters a illegally
 	// formatted numerical form.
 	ErrNumberFormat = errors.New("invalid number format")
@@ -28,9 +23,7 @@ var (
 // some issue. Use errors.Is() with Cause to check for specific underlying
 // errors.
 type Error struct {
-	Form       string
 	Cause      error
-	Rune       rune
 	Begin, End Position
 }
 
@@ -40,11 +33,27 @@ func (e Error) Is(other error) bool { return errors.Is(e.Cause, other) }
 // Unwrap returns the underlying cause of the error.
 func (e Error) Unwrap() error { return e.Cause }
 
-func (e Error) Error() string {
-	cause := e.Cause
-	if errors.Is(cause, ErrUnmatchedDelimiter) {
-		cause = fmt.Errorf("unmatched delimiter '%c'", e.Rune)
+func (e Error) Error() string { return fmt.Sprintf("ReaderError: %v", e.Cause) }
+
+func (e Error) Format(s fmt.State, verb rune) {
+	if !s.Flag('#') {
+		fmt.Fprint(s, e.Error())
+		return
 	}
 
-	return fmt.Sprintf("error while reading: %v", cause)
+	/*
+	 * File "<REPL>" line 1, column 2
+	 * ReaderError:  unmatched delimiter ']'
+	 */
+	fmt.Fprintf(s, "File \"%s\" line %d, column %d\n",
+		e.Begin.File,
+		e.Begin.Ln,
+		e.Begin.Col)
+	fmt.Fprintf(s, "ReaderError: %s", e.Error())
+}
+
+type unmatchedDelimiterError rune
+
+func (r unmatchedDelimiterError) Error() string {
+	return fmt.Sprintf("unmatched delimiter '%c'", r)
 }

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -381,19 +381,17 @@ func (rd *Reader) execDispatch() (core.Any, error) {
 	return form, nil
 }
 
-func (rd *Reader) annotateErr(err error, beginPos Position, form string) error {
+func (rd *Reader) annotateErr(err error, beginPos Position /*, form string */) error {
 	if err == io.EOF || err == ErrSkip {
 		return err
 	}
 
-	readErr := Error{}
-	if e, ok := err.(Error); ok {
-		readErr = e
-	} else {
-		readErr = Error{Cause: err}
+	readErr, ok := err.(Error)
+	if !ok {
+		readErr.Cause = err
 	}
 
-	readErr.Form = form
+	// readErr.Form = form
 	readErr.Begin = beginPos
 	readErr.End = rd.Position()
 	return readErr

--- a/repl/reader.go
+++ b/repl/reader.go
@@ -1,0 +1,72 @@
+package repl
+
+import (
+	"bufio"
+	"io"
+	"strings"
+)
+
+// Input implementation is used by REPL to read user-input. See WithInput()
+// REPL option to configure an Input.
+type Input interface {
+	Readline() (string, error)
+}
+
+// Prompter is an optional interface for Input.  If provided, the REPL
+// will attempt to set a prompt during the read-phase.
+type Prompter interface {
+	Prompt(string)
+}
+
+// LineReader is a simple Input that uses bufio.Scanner.
+type LineReader struct{ s *bufio.Scanner }
+
+// NewLineReader that reads from r.
+func NewLineReader(r io.Reader) LineReader {
+	return LineReader{bufio.NewScanner(r)}
+}
+
+func (lr LineReader) Readline() (string, error) {
+	if !lr.s.Scan() {
+		if lr.s.Err() == nil { // scanner swallows EOF
+			return lr.s.Text(), io.EOF
+		}
+
+		return "", lr.s.Err()
+	}
+
+	return lr.s.Text(), nil
+}
+
+// Prompt is an interactive Input that that can signals 'out' when it is
+// ready to receive data.
+type Prompt struct {
+	in     Input
+	out    io.Writer
+	prompt *strings.Reader
+}
+
+func NewPrompt(in Input, out io.Writer) *Prompt {
+	return &Prompt{
+		in:     in,
+		out:    out,
+		prompt: &strings.Reader{},
+	}
+}
+
+func (p *Prompt) Prompt(s string) { p.prompt.Reset(s) }
+
+func (p *Prompt) Readline() (string, error) {
+	if err := p.writePrompt(); err != nil {
+		return "", err
+	}
+
+	return p.in.Readline()
+}
+
+func (p *Prompt) writePrompt() error {
+	defer p.prompt.Seek(0, io.SeekStart)
+
+	_, err := io.Copy(p.out, p.prompt)
+	return err
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -12,21 +12,6 @@ import (
 	"github.com/spy16/slurp/reader"
 )
 
-// New returns a new instance of REPL with given slurp Env. Option values
-// can be used to configure REPL input, output etc.
-func New(exec Evaluator, opts ...Option) *REPL {
-	repl := &REPL{
-		exec:      exec,
-		currentNS: func() string { return "" },
-	}
-
-	for _, option := range withDefaults(opts) {
-		option(repl)
-	}
-
-	return repl
-}
-
 // Evaluator implementation is responsible for executing givenn forms.
 type Evaluator interface {
 	Eval(form core.Any) (core.Any, error)
@@ -36,23 +21,29 @@ type Evaluator interface {
 type REPL struct {
 	exec        Evaluator
 	input       Input
-	output      io.Writer
+	output      Printer
 	mapInputErr ErrMapper
-	currentNS   func() string
 	factory     ReaderFactory
 
-	banner      string
+	banner string
+
+	prompter    Prompter
 	prompt      string
 	multiPrompt string
-
-	printer Printer
 }
 
-// Input implementation is used by REPL to read user-input. See WithInput()
-// REPL option to configure an Input.
-type Input interface {
-	SetPrompt(string)
-	Readline() (string, error)
+// New returns a new instance of REPL with given slurp Env. Option values
+// can be used to configure REPL input, output etc.
+func New(exec Evaluator, opts ...Option) *REPL {
+	repl := &REPL{exec: exec}
+
+	for _, option := range withDefaults(opts) {
+		option(repl)
+	}
+
+	repl.prompter, _ = repl.input.(Prompter)
+
+	return repl
 }
 
 // Loop starts the read-eval-print loop. Loop runs until context is cancelled
@@ -81,7 +72,7 @@ func (repl *REPL) readEvalPrint() error {
 	if err != nil {
 		switch err.(type) {
 		case reader.Error:
-			_ = repl.print(err)
+			_ = repl.output.Print(err)
 		default:
 			return err
 		}
@@ -93,25 +84,13 @@ func (repl *REPL) readEvalPrint() error {
 
 	res, err := evalAll(repl.exec, forms)
 	if err != nil {
-		return repl.print(err)
+		return repl.output.Print(err)
 	}
 	if len(res) == 0 {
-		return repl.print(nil)
+		return repl.output.Print(nil)
 	}
 
-	return repl.print(res[len(res)-1])
-}
-
-func (repl *REPL) Write(b []byte) (int, error) {
-	return repl.output.Write(b)
-}
-
-func (repl *REPL) print(v interface{}) error {
-	if e, ok := v.(reader.Error); ok {
-		s := fmt.Sprintf("%v (begin=%s, end=%s)", e, e.Begin, e.End)
-		return repl.printer.Fprintln(repl.output, s)
-	}
-	return repl.printer.Fprintln(repl.output, v)
+	return repl.output.Print(res[len(res)-1])
 }
 
 func (repl *REPL) read() ([]core.Any, error) {
@@ -122,8 +101,7 @@ func (repl *REPL) read() ([]core.Any, error) {
 		repl.setPrompt(lineNo > 1)
 
 		line, err := repl.input.Readline()
-		err = repl.mapInputErr(err)
-		if err != nil {
+		if err = repl.mapInputErr(err); err != nil {
 			return nil, err
 		}
 
@@ -134,7 +112,7 @@ func (repl *REPL) read() ([]core.Any, error) {
 		}
 
 		rd := repl.factory.NewReader(strings.NewReader(src))
-		rd.File = "REPL"
+		rd.File = "<REPL>"
 
 		form, err := rd.All()
 		if err != nil {
@@ -150,8 +128,12 @@ func (repl *REPL) read() ([]core.Any, error) {
 	}
 }
 
+func (repl *REPL) currentNS() string {
+	return "" // stub
+}
+
 func (repl *REPL) setPrompt(multiline bool) {
-	if repl.prompt == "" {
+	if repl.prompter == nil || repl.prompt == "" {
 		return
 	}
 
@@ -163,7 +145,7 @@ func (repl *REPL) setPrompt(multiline bool) {
 		prompt = repl.multiPrompt
 	}
 
-	repl.input.SetPrompt(fmt.Sprintf("%s%s ", nsPrefix, prompt))
+	repl.prompter.Prompt(fmt.Sprintf("%s%s ", nsPrefix, prompt))
 }
 
 func (repl *REPL) printBanner() {

--- a/slurp_test.go
+++ b/slurp_test.go
@@ -1,0 +1,108 @@
+package slurp_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spy16/slurp"
+	"github.com/spy16/slurp/builtin"
+	"github.com/spy16/slurp/core"
+	"github.com/spy16/slurp/repl"
+)
+
+var testdir string = "./test"
+
+func init() {
+	flag.StringVar(&testdir, "testdir", testdir, "root test directory (default: ./test)")
+}
+
+func TestSlurp(t *testing.T) {
+	t.Parallel()
+	t.Helper()
+
+	if err := filepath.Walk(testdir, visit(t)); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}
+
+func visit(t *testing.T) filepath.WalkFunc {
+	return func(path string, info fs.FileInfo, err error) error {
+		t.Helper()
+
+		if err != nil {
+			t.Logf("skipping %s:  %s", path, err)
+		} else if !info.IsDir() {
+			t.Run(path, run(t, path, info))
+		}
+
+		return nil
+	}
+}
+
+func run(t *testing.T, path string, file fs.FileInfo) func(*testing.T) {
+	return func(t *testing.T) {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Errorf("open file:  %s", err)
+		}
+		defer f.Close()
+
+		r := repl.New(evaluator(t),
+			repl.WithInput(repl.NewLineReader(f), nil),
+			repl.WithPrinter(printer{t}))
+
+		if err := r.Loop(context.Background()); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+func evaluator(t *testing.T) repl.Evaluator {
+	env := core.New(map[string]core.Any{
+		"nil?": slurp.Func("is-nil", builtin.IsNil),
+		"not": slurp.Func("not", func(any core.Any) bool {
+			return builtin.IsTruthy(any) == false
+		}),
+		"=": slurp.Func("equal", core.Eq),
+		"!=": slurp.Func("not-equal", func(a, b core.Any) (bool, error) {
+			eq, err := core.Eq(a, b)
+			return !eq, err
+		}),
+		"<": slurp.Func("less-than", func(a, b core.Any) (bool, error) {
+			i, err := core.Compare(a, b)
+			return i < 0, err
+		}),
+		">": slurp.Func("greater-than", func(a, b core.Any) (bool, error) {
+			i, err := core.Compare(a, b)
+			return i > 0, err
+		}),
+		"<=": slurp.Func("less-than-or-eq", func(a, b core.Any) (bool, error) {
+			i, err := core.Compare(a, b)
+			return i <= 0, err
+		}),
+		">=": slurp.Func("greater-than-or-eq", func(a, b core.Any) (bool, error) {
+			i, err := core.Compare(a, b)
+			return i >= 0, err
+		}),
+	})
+
+	return slurp.New(slurp.WithEnv(env))
+}
+
+type printer struct{ t *testing.T }
+
+func (p printer) Print(v interface{}) error {
+	if err, ok := v.(error); ok {
+		p.t.Errorf("runtime error: %v", err)
+	} else if !builtin.IsTruthy(v) {
+		p.t.Fail()
+	}
+
+	return nil
+}

--- a/test/basic.slurp
+++ b/test/basic.slurp
@@ -1,0 +1,6 @@
+;; basic sanity-check tests
+(= 1 1)
+(!= 1 2)
+(nil? nil)
+(not (nil? false))
+;; (= true (not false))  ;; wtf??


### PR DESCRIPTION
⚠️ Merge #16 prior to reviewing ⚠️ 

This PR adds some basic lisp-based unit tests to ensure expected behavior.  The mechanism is simple and expedient:  `slurp_test.go` will recursively evaluate all files located in the `test/` subdirectory.

Note that there is a commented test in `test/basic.slurp` that currently fails.  (@spy16 Any idea what's going on there?)

⏱️ Estimated review time:  15 minutes
✅ Merge when ready