### PR TITLE
Implement namespaces

### DIFF
--- a/builtin/analyzer.go
+++ b/builtin/analyzer.go
@@ -34,7 +34,7 @@ func (ba Analyzer) Analyze(env core.Env, form core.Any) (core.Expr, error) {
 	}
 
 	switch f := exp.(type) {
-	case Symbol:
+	case core.Symbol:
 		return ResolveExpr{Symbol: f}, nil
 
 	case core.Vector:
@@ -67,8 +67,8 @@ func (ba Analyzer) analyzeSeq(env core.Env, seq core.Seq) (core.Expr, error) {
 	// The call target may be a special form.  In this case, we need to get the
 	// corresponding parser function, which will take care of parsing/analyzing
 	// the tail.
-	if sym, ok := first.(Symbol); ok {
-		if parse, found := ba.Specials[string(sym)]; found {
+	if sym, ok := first.(core.Symbol); ok && !sym.Qualified() {
+		if parse, found := ba.Specials[sym.String()]; found {
 			next, err := seq.Next()
 			if err != nil {
 				return nil, err
@@ -117,7 +117,7 @@ func macroExpand1(env core.Env, form core.Any) (core.Any, error) {
 	}
 
 	var target core.Any
-	sym, ok := first.(Symbol)
+	sym, ok := first.(core.Symbol)
 	if ok {
 		v, err := ResolveExpr{Symbol: sym}.Eval(env)
 		if err != nil {

--- a/builtin/analyzer_test.go
+++ b/builtin/analyzer_test.go
@@ -14,10 +14,10 @@ func TestBuiltinAnalyzer_Analyze(t *testing.T) {
 	t.Parallel()
 
 	hundredFunc := fakeFn{}
-	e := builtin.NewEnv(map[string]core.Any{
+	e := builtin.NewEnv(builtin.WithNamespace("", map[string]core.Any{
 		"foo":     builtin.Keyword("hello"),
 		"hundred": hundredFunc,
-	})
+	}))
 
 	table := []struct {
 		title   string
@@ -48,7 +48,7 @@ func TestBuiltinAnalyzer_Analyze(t *testing.T) {
 			form:  builtin.NewList(builtin.Symbol("hundred"), 1),
 			want: builtin.InvokeExpr{
 				Name:   "hundred",
-				Target: builtin.ResolveExpr{Symbol: "hundred"},
+				Target: builtin.ResolveExpr{Symbol: builtin.Symbol("hundred")},
 				Args:   []core.Expr{builtin.ConstExpr{Const: 1}},
 			},
 		},
@@ -83,7 +83,7 @@ func TestBultinAnalyzer_Analyze_Vector(t *testing.T) {
 	vec := builtin.NewVector(builtin.Symbol("foo"))
 
 	var ba builtin.Analyzer
-	expr, err := ba.Analyze(builtin.NewEnv(nil), vec)
+	expr, err := ba.Analyze(builtin.NewEnv(), vec)
 	require.NoError(t, err)
 	require.IsType(t, builtin.VectorExpr{}, expr)
 	assert.Equal(t, vec, expr.(builtin.VectorExpr).Vector)

--- a/builtin/analyzer_test.go
+++ b/builtin/analyzer_test.go
@@ -14,7 +14,7 @@ func TestBuiltinAnalyzer_Analyze(t *testing.T) {
 	t.Parallel()
 
 	hundredFunc := fakeFn{}
-	e := core.New(map[string]core.Any{
+	e := builtin.NewEnv(map[string]core.Any{
 		"foo":     builtin.Keyword("hello"),
 		"hundred": hundredFunc,
 	})
@@ -83,7 +83,7 @@ func TestBultinAnalyzer_Analyze_Vector(t *testing.T) {
 	vec := builtin.NewVector(builtin.Symbol("foo"))
 
 	var ba builtin.Analyzer
-	expr, err := ba.Analyze(core.New(nil), vec)
+	expr, err := ba.Analyze(builtin.NewEnv(nil), vec)
 	require.NoError(t, err)
 	require.IsType(t, builtin.VectorExpr{}, expr)
 	assert.Equal(t, vec, expr.(builtin.VectorExpr).Vector)

--- a/builtin/env.go
+++ b/builtin/env.go
@@ -1,0 +1,77 @@
+package builtin
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/spy16/slurp/core"
+)
+
+const rootEnv = "<main>"
+
+// NewEnv returns a root Env that can be used to execute forms.
+func NewEnv(globals map[string]core.Any) *Env {
+	if globals == nil {
+		globals = map[string]core.Any{}
+	}
+	return &Env{
+		parent: nil,
+		name:   rootEnv,
+		vars:   globals,
+	}
+}
+
+// Env implements Env using a Go native map and RWMutex.
+type Env struct {
+	parent core.Env
+	name   string
+	mu     sync.RWMutex
+	vars   map[string]core.Any
+}
+
+func (env *Env) Name() string     { return env.name }
+func (env *Env) Parent() core.Env { return env.parent }
+
+func (env *Env) Child(name string, vars map[string]core.Any) core.Env {
+	if vars == nil {
+		vars = map[string]core.Any{}
+	}
+	return &Env{
+		name:   name,
+		parent: env,
+		vars:   vars,
+	}
+}
+
+func (env *Env) Bind(name string, val core.Any) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("%w: %s", core.ErrInvalidName, name)
+	}
+
+	if env.parent == nil {
+		// only root env is shared between threads. so make sure
+		// concurrent accesses are synchronized.
+		env.mu.Lock()
+		defer env.mu.Unlock()
+	}
+
+	env.vars[name] = val
+	return nil
+}
+
+func (env *Env) Resolve(name string) (core.Any, error) {
+	if env.parent == nil {
+		// only root env is shared between threads. so make sure
+		// concurrent accesses are synchronized.
+		env.mu.RLock()
+		defer env.mu.RUnlock()
+	}
+
+	v, found := env.vars[name]
+	if !found {
+		return nil, fmt.Errorf("%w: %s", core.ErrNotFound, name)
+	}
+	return v, nil
+}

--- a/builtin/env.go
+++ b/builtin/env.go
@@ -1,77 +1,273 @@
 package builtin
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/spy16/slurp/core"
 )
 
-const rootEnv = "<main>"
+// Env is a global environment.
+type Env struct {
+	active core.Namespace
+	scope  *globalScope
+
+	mu *sync.RWMutex
+	ns map[string]*globalScope
+}
 
 // NewEnv returns a root Env that can be used to execute forms.
-func NewEnv(globals map[string]core.Any) *Env {
-	if globals == nil {
-		globals = map[string]core.Any{}
+func NewEnv(opt ...Option) core.Env {
+	env := Env{mu: new(sync.RWMutex)}
+
+	for _, option := range withDefault(opt) {
+		option(&env)
 	}
-	return &Env{
-		parent: nil,
-		name:   rootEnv,
-		vars:   globals,
+
+	return env
+}
+
+// Name returns the active namespace.
+func (env Env) Name() string { return "<main>" }
+
+// Namespace returns the active namespace.
+func (env Env) Namespace() core.Namespace { return env.active }
+
+// Parent is nil.
+func (Env) Parent() core.Env { return nil }
+
+// Scope returns the scope for the active namespace.
+// Scope's methods are safe for concurrent access.
+func (env Env) Scope() core.Scope { return parseScope(env) }
+
+// MaybeScope returns the scope for the supplied namespace,
+// it exists. Else, it returns a Scope whose methods return
+// an error.
+//
+// It is intended for use inside of SymbolParser, in order to
+// resolve relative symbols.
+//
+// To access the global scope without parsing, use
+//     env.MaybeScope(env.Namespace())
+func (env Env) MaybeScope(ns core.Namespace) core.Scope {
+	name := ns.String()
+	if name == env.active.String() {
+		return env.scope
+	}
+
+	env.mu.RLock()
+	defer env.mu.RUnlock()
+
+	if scope, ok := env.ns[name]; ok {
+		return scope
+	}
+
+	return errScope{
+		Cause:   core.ErrNotFound,
+		Message: name,
 	}
 }
 
-// Env implements Env using a Go native map and RWMutex.
-type Env struct {
-	parent core.Env
-	name   string
-	mu     sync.RWMutex
-	vars   map[string]core.Any
+func (env Env) WithNamespace(ns core.Namespace) core.Env {
+	name := ns.String()
+	if name == env.active.String() {
+		return env
+	}
+
+	env.mu.Lock()
+	defer env.mu.Unlock()
+
+	var ok bool
+	if env.scope, ok = env.ns[name]; !ok {
+		env.scope = &globalScope{vars: map[string]core.Any{}}
+		env.ns[name] = env.scope
+	}
+
+	// 'env' is a copy, so no need to allocate
+	env.active = ns
+	// env.scope.env = &env
+	return env
 }
 
-func (env *Env) Name() string     { return env.name }
-func (env *Env) Parent() core.Env { return env.parent }
-
-func (env *Env) Child(name string, vars map[string]core.Any) core.Env {
+// Child returns a new environment with 'env' as it's parent.
+// The child environment is logically contained within the parent's
+// active namespace.
+//
+// Note that the child's scope is NOT safe for concurrent access.
+func (env Env) Child(name string, vars map[string]core.Any) core.Env {
 	if vars == nil {
 		vars = map[string]core.Any{}
 	}
-	return &Env{
+
+	return childEnv{
 		name:   name,
+		active: env.active,
 		parent: env,
-		vars:   vars,
+		scope:  vars,
 	}
 }
 
-func (env *Env) Bind(name string, val core.Any) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("%w: %s", core.ErrInvalidName, name)
+type childEnv struct {
+	name   string
+	active core.Namespace
+	parent core.Env
+	scope  localScope
+}
+
+func (env childEnv) Name() string              { return env.name }
+func (env childEnv) Namespace() core.Namespace { return env.active }
+func (env childEnv) Parent() core.Env          { return env.parent }
+func (env childEnv) Scope() core.Scope         { return env.scope }
+
+func (env childEnv) WithNamespace(ns core.Namespace) core.Env {
+	// XXX:  what happens if we're already in the namespace?  Scope will be cleared.
+
+	// TODO:  what is the expected behavior when calling something like this?
+	//			(let []
+	//				(ns foo))
+	//
+	return childEnv{
+		name:   ns.String(),
+		parent: env.parent.WithNamespace(ns),
+		scope:  localScope{},
+	}
+}
+
+func (env childEnv) Child(name string, vars map[string]core.Any) core.Env {
+	if vars == nil {
+		vars = map[string]core.Any{}
 	}
 
-	if env.parent == nil {
-		// only root env is shared between threads. so make sure
-		// concurrent accesses are synchronized.
-		env.mu.Lock()
-		defer env.mu.Unlock()
+	return childEnv{
+		parent: env,
+		scope:  vars,
+	}
+}
+
+type Option func(*Env)
+
+// WithNamespace sets the active namespace.
+func WithNamespace(ns core.Namespace, vars map[string]core.Any) Option {
+	if vars == nil {
+		vars = map[string]core.Any{}
 	}
 
-	env.vars[name] = val
+	return func(env *Env) {
+		env.active = ns
+		env.scope = &globalScope{vars: vars}
+		env.ns = map[string]*globalScope{ns.String(): env.scope}
+	}
+}
+
+func withDefault(opt []Option) []Option {
+	return append([]Option{
+		WithNamespace("", nil),
+	}, opt...)
+}
+
+// globalScope is safe for concurrent access.
+type globalScope struct {
+	/*
+	 * TODO(performance):  investigate optimistic concurrency-control.
+	 *
+	 * Rationale is that access to the global scope is likely to be
+	 * dominated by read operations, with relatively few writes.
+	 * If so, it seems desirable for readers to never block, even in
+	 * the presence of concurrent writers.
+	 *
+	 * The simplest solution would be a CAS loop on a map[string]core.Any.
+	 * Although this would involve copying the map on each write, the
+	 * overhead may be negligible.  A more complex solution would involve
+	 * the use of immutable maps, but the constant factors are likely
+	 * to be much higher.
+	 */
+
+	mu   sync.RWMutex
+	vars map[string]core.Any
+}
+
+func (gs *globalScope) Bind(s core.Symbol, value core.Any) error {
+	if !s.Valid() {
+		return fmt.Errorf("%w: %s", core.ErrInvalidName, s)
+	}
+
+	gs.mu.Lock()
+	defer gs.mu.Unlock()
+
+	gs.vars[s.String()] = value
 	return nil
 }
 
-func (env *Env) Resolve(name string) (core.Any, error) {
-	if env.parent == nil {
-		// only root env is shared between threads. so make sure
-		// concurrent accesses are synchronized.
-		env.mu.RLock()
-		defer env.mu.RUnlock()
+func (gs *globalScope) Resolve(s core.Symbol) (core.Any, error) {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	if v, found := gs.vars[s.String()]; found {
+		return v, nil
 	}
 
-	v, found := env.vars[name]
-	if !found {
-		return nil, fmt.Errorf("%w: %s", core.ErrNotFound, name)
-	}
-	return v, nil
+	return nil, fmt.Errorf("%w: %s", core.ErrNotFound, s)
 }
+
+// localScope stores local variables.
+type localScope map[string]core.Any
+
+func (vars localScope) Bind(s core.Symbol, val core.Any) error {
+	if !s.Valid() {
+		return fmt.Errorf("%w: %s", core.ErrInvalidName, s)
+	}
+
+	vars[s.String()] = val
+	return nil
+}
+
+func (vars localScope) Resolve(s core.Symbol) (core.Any, error) {
+	if v, found := vars[s.String()]; found {
+		return v, nil
+	}
+
+	return nil, fmt.Errorf("%w: %s", core.ErrNotFound, s)
+}
+
+type parseScope Env
+
+func (p parseScope) parse(s core.Symbol) (core.Scope, core.Symbol) {
+	if s.Qualified() {
+		return Env(p).MaybeScope(s.Namespace()), s.Relative()
+	}
+
+	return Env(p).MaybeScope(Env(p).Namespace()), s
+}
+
+func (p parseScope) Bind(s core.Symbol, val core.Any) error {
+	scope, s := p.parse(s)
+	return scope.Bind(s, val)
+}
+
+func (p parseScope) Resolve(s core.Symbol) (core.Any, error) {
+	scope, s := p.parse(s)
+	return scope.Resolve(s)
+}
+
+// errScope wraps an error, and returns it immediately from
+// its methods.
+type errScope struct {
+	Cause   error
+	Message string
+}
+
+func (err errScope) Bind(core.Symbol, core.Any) error      { return err }
+func (err errScope) Resolve(core.Symbol) (core.Any, error) { return nil, err }
+
+func (err errScope) Error() string {
+	if err.Cause == nil {
+		return err.Message
+	}
+
+	return fmt.Sprintf("%s: %s", err.Cause, err.Message)
+}
+
+// Is returns true if the other error is same as the cause of this error.
+func (err errScope) Is(other error) bool { return errors.Is(err.Cause, other) }
+func (err errScope) Unwrap() error       { return err.Cause }

--- a/builtin/env_test.go
+++ b/builtin/env_test.go
@@ -1,0 +1,39 @@
+package builtin_test
+
+import (
+	"testing"
+
+	"github.com/spy16/slurp/builtin"
+	"github.com/spy16/slurp/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoot(t *testing.T) {
+	root := builtin.NewEnv(nil)
+	child := root.Child("foo", nil)
+	got := core.Root(child)
+	require.NotEqual(t, child, got, "expecting root, got child")
+	require.Equal(t, root, got, "returned env is not root")
+	require.Equal(t, root.Name(), got.Name(), "wrong name for root env")
+}
+
+func Test_Env_Bind_Resolve(t *testing.T) {
+	var v core.Any
+	var err error
+
+	env := builtin.NewEnv(map[string]core.Any{"foo": "bar"})
+
+	err = env.Bind("v", 1000)
+	require.NoError(t, err)
+
+	err = env.Bind("", 1000)
+	require.ErrorIs(t, err, core.ErrInvalidName)
+
+	v, err = env.Resolve("foo")
+	require.NoError(t, err)
+	require.Equal(t, "bar", v)
+
+	v, err = env.Resolve("non-existent")
+	require.ErrorIs(t, err, core.ErrNotFound)
+	require.Nil(t, v)
+}

--- a/builtin/expr.go
+++ b/builtin/expr.go
@@ -234,14 +234,12 @@ func (vex VectorExpr) Eval(env core.Env) (core.Any, error) {
 	return vex.Vector, nil
 }
 
-// // NamespaceExpr modifies a namespace.
-// type NamespaceExpr struct {
-// 	NS string
-// 	Do DoExpr
-// }
+// NamespaceExpr modifies a namespace.
+type NamespaceExpr struct {
+	NS core.Namespace
+}
 
-// // Eval modifies the designated namespace.
-// func (nex NamespaceExpr) Eval(env core.Env) (core.Any, error) {
-// 	panic("NOT IMPLEMENTED")
-// 	// return nex.Do.Eval(env.WithNamespace(nex.NS))
-// }
+// Eval modifies the designated namespace.
+func (nex NamespaceExpr) Eval(env core.Env) (core.Any, error) {
+	return nex.NS, core.NamespaceInterrupt{Env: env.WithNamespace(nex.NS)}
+}

--- a/builtin/expr.go
+++ b/builtin/expr.go
@@ -33,14 +33,12 @@ func (qe QuoteExpr) Eval(_ core.Env) (core.Any, error) { return qe.Form, nil }
 
 // DefExpr represents the (def name value) binding form.
 type DefExpr struct {
-	Name  string
+	Name  core.Symbol
 	Value core.Expr
 }
 
 // Eval creates the binding with the name and value in Root env.
-func (de DefExpr) Eval(env core.Env) (core.Any, error) {
-	var val core.Any
-	var err error
+func (de DefExpr) Eval(env core.Env) (val core.Any, err error) {
 	if de.Value != nil {
 		val, err = de.Value.Eval(env)
 		if err != nil {
@@ -50,10 +48,10 @@ func (de DefExpr) Eval(env core.Env) (core.Any, error) {
 		val = Nil{}
 	}
 
-	if err := core.Root(env).Bind(de.Name, val); err != nil {
+	if err := core.Root(env).Scope().Bind(de.Name, val); err != nil {
 		return nil, err
 	}
-	return Symbol(de.Name), nil
+	return de.Name, nil
 }
 
 // LetExpr represents the (let [param*] expr*) binding form.
@@ -122,7 +120,7 @@ func (de DoExpr) Eval(env core.Env) (core.Any, error) {
 }
 
 // ResolveExpr resolves a symbol from the given environment.
-type ResolveExpr struct{ Symbol Symbol }
+type ResolveExpr struct{ Symbol core.Symbol }
 
 // Eval resolves the symbol in the given environment or its parent env
 // and returns the result. Returns ErrNotFound if the symbol was not
@@ -131,7 +129,7 @@ func (re ResolveExpr) Eval(env core.Env) (core.Any, error) {
 	var v core.Any
 	var err error
 	for env != nil {
-		v, err = env.Resolve(string(re.Symbol))
+		v, err = env.Scope().Resolve(re.Symbol)
 		if errors.Is(err, core.ErrNotFound) {
 			// not found in the current frame. check parent.
 			env = env.Parent()
@@ -235,3 +233,15 @@ func (vex VectorExpr) Eval(env core.Env) (core.Any, error) {
 
 	return vex.Vector, nil
 }
+
+// // NamespaceExpr modifies a namespace.
+// type NamespaceExpr struct {
+// 	NS string
+// 	Do DoExpr
+// }
+
+// // Eval modifies the designated namespace.
+// func (nex NamespaceExpr) Eval(env core.Env) (core.Any, error) {
+// 	panic("NOT IMPLEMENTED")
+// 	// return nex.Do.Eval(env.WithNamespace(nex.NS))
+// }

--- a/builtin/expr_test.go
+++ b/builtin/expr_test.go
@@ -81,17 +81,17 @@ func TestDefExpr_Eval(t *testing.T) {
 		{
 			title: "NoName",
 			expr: func() (core.Expr, core.Env) {
-				return DefExpr{}, core.New(nil)
+				return DefExpr{}, NewEnv(nil)
 			},
 			wantErr: core.ErrInvalidName,
 		},
 		{
 			title: "NilValue",
 			expr: func() (core.Expr, core.Env) {
-				return DefExpr{Name: "foo"}, core.New(nil)
+				return DefExpr{Name: "foo"}, NewEnv(nil)
 			},
 			want: Symbol("foo"),
-			assert: func(t *testing.T, got core.Any, err error, env core.Env) {
+			assert: func(t *testing.T, got core.Any, _ error, env core.Env) {
 				v, err := env.Resolve("foo")
 				assert.NoError(t, err)
 				assert.Equal(t, Nil{}, v)
@@ -103,7 +103,7 @@ func TestDefExpr_Eval(t *testing.T) {
 				return DefExpr{
 					Name:  "foo",
 					Value: fakeExpr{Err: errUnknown},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: errUnknown,
 		},
@@ -113,10 +113,10 @@ func TestDefExpr_Eval(t *testing.T) {
 				return DefExpr{
 					Name:  "foo",
 					Value: ConstExpr{Const: 10},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			want: Symbol("foo"),
-			assert: func(t *testing.T, got core.Any, err error, env core.Env) {
+			assert: func(t *testing.T, got core.Any, _ error, env core.Env) {
 				v, err := env.Resolve("foo")
 				assert.NoError(t, err)
 				assert.Equal(t, 10, v)
@@ -132,7 +132,7 @@ func TestIfExpr_Eval(t *testing.T) {
 		{
 			title: "EmptyIf",
 			expr: func() (core.Expr, core.Env) {
-				return IfExpr{}, core.New(nil)
+				return IfExpr{}, NewEnv(nil)
 			},
 			want: Nil{},
 		},
@@ -141,7 +141,7 @@ func TestIfExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return IfExpr{
 					Test: ConstExpr{Const: true},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			want: Nil{},
 		},
@@ -150,7 +150,7 @@ func TestIfExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return IfExpr{
 					Test: ConstExpr{Const: false},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			want: Nil{},
 		},
@@ -160,7 +160,7 @@ func TestIfExpr_Eval(t *testing.T) {
 				return IfExpr{
 					Test: ConstExpr{Const: true},
 					Then: ConstExpr{Const: "hello"},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			want: "hello",
 		},
@@ -169,7 +169,7 @@ func TestIfExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return IfExpr{
 					Test: fakeExpr{Err: errUnknown},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: errUnknown,
 		},
@@ -179,7 +179,7 @@ func TestIfExpr_Eval(t *testing.T) {
 				return IfExpr{
 					Test: ConstExpr{Const: false},
 					Else: ConstExpr{Const: "else-case"},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			want: "else-case",
 		},
@@ -194,7 +194,7 @@ func TestGoExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return &GoExpr{
 					Form: fakeExpr{Err: errUnknown},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: nil,
 		},
@@ -203,7 +203,7 @@ func TestGoExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return &GoExpr{
 					Form: fakeExpr{Res: 100},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: nil,
 		},
@@ -218,7 +218,7 @@ func TestInvokeExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return &InvokeExpr{
 					Target: fakeExpr{Err: errUnknown},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: errUnknown,
 		},
@@ -227,14 +227,14 @@ func TestInvokeExpr_Eval(t *testing.T) {
 			expr: func() (core.Expr, core.Env) {
 				return &InvokeExpr{
 					Target: ConstExpr{Const: 10},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: core.ErrNotInvokable,
 		},
 		{
 			title: "InvokeWithArgs",
 			expr: func() (core.Expr, core.Env) {
-				e := core.New(nil)
+				e := NewEnv(nil)
 				return &InvokeExpr{
 					Name: "foo",
 					Target: ConstExpr{Const: fakeInvokable(func(args ...core.Any) (core.Any, error) {
@@ -255,7 +255,7 @@ func TestInvokeExpr_Eval(t *testing.T) {
 					Args: []core.Expr{
 						fakeExpr{Err: errUnknown},
 					},
-				}, core.New(nil)
+				}, NewEnv(nil)
 			},
 			wantErr: errUnknown,
 		},
@@ -282,7 +282,7 @@ func TestVectorExpr_Eval(t *testing.T) {
 	})
 
 	t.Run("SymbolMember", func(t *testing.T) {
-		env := core.New(map[string]core.Any{"foo": Keyword("foo")})
+		env := NewEnv(map[string]core.Any{"foo": Keyword("foo")})
 		vec := NewVector(Symbol("foo"))
 
 		any, err := (VectorExpr{
@@ -306,7 +306,7 @@ func TestVectorExpr_Eval(t *testing.T) {
 		any, err := (VectorExpr{
 			Analyzer: &Analyzer{},
 			Vector:   vec,
-		}).Eval(core.New(nil))
+		}).Eval(NewEnv(nil))
 
 		assert.Error(t, err)
 		assert.Nil(t, any)

--- a/builtin/fn.go
+++ b/builtin/fn.go
@@ -108,12 +108,12 @@ func (f Func) matchArity(args []core.Any) bool {
 	return argc == len(f.Params)
 }
 
-func (f Func) minArity() int {
-	if len(f.Params) > 0 && f.Variadic {
-		return len(f.Params) - 1
-	}
-	return len(f.Params)
-}
+// func (f Func) minArity() int {
+// 	if len(f.Params) > 0 && f.Variadic {
+// 		return len(f.Params) - 1
+// 	}
+// 	return len(f.Params)
+// }
 
 func (f *Func) compare(other Func) (bool, error) {
 	if f.Variadic != other.Variadic ||

--- a/builtin/fn.go
+++ b/builtin/fn.go
@@ -33,7 +33,7 @@ func (fn Fn) Invoke(args ...core.Any) (core.Any, error) {
 
 	env := fn.Env.Child(fn.Name, nil)
 	for i, p := range f.Params {
-		if err := env.Bind(p, args[i]); err != nil {
+		if err := env.Scope().Bind(p, args[i]); err != nil {
 			return nil, err
 		}
 	}
@@ -96,7 +96,7 @@ func (fn Fn) selectFunc(args []core.Any) (Func, error) {
 // Func represents a method of specific arity in Fn.
 type Func struct {
 	Body     core.Expr
-	Params   []string
+	Params   []core.Symbol
 	Variadic bool
 }
 

--- a/builtin/fn_test.go
+++ b/builtin/fn_test.go
@@ -12,13 +12,13 @@ func TestFn_Invoke(t *testing.T) {
 	t.Parallel()
 
 	specimen := Fn{
-		Env:  NewEnv(nil),
+		Env:  NewEnv(),
 		Name: "foo",
 		Funcs: []Func{
 			{
 				Variadic: false,
-				Params:   []string{"arg0"},
-				Body:     &ResolveExpr{"arg0"},
+				Params:   []core.Symbol{Symbol("arg0")},
+				Body:     &ResolveExpr{Symbol("arg0")},
 			},
 		},
 		Macro: false,

--- a/builtin/fn_test.go
+++ b/builtin/fn_test.go
@@ -12,7 +12,7 @@ func TestFn_Invoke(t *testing.T) {
 	t.Parallel()
 
 	specimen := Fn{
-		Env:  core.New(nil),
+		Env:  NewEnv(nil),
 		Name: "foo",
 		Funcs: []Func{
 			{

--- a/builtin/symbol.go
+++ b/builtin/symbol.go
@@ -1,0 +1,71 @@
+package builtin
+
+import (
+	"strings"
+
+	"github.com/spy16/slurp/core"
+)
+
+var (
+	_ core.Any = (*fq)(nil)
+	_ core.Any = (*rel)(nil)
+
+	_ core.Symbol = (*fq)(nil)
+	_ core.Symbol = (*rel)(nil)
+
+	_ core.EqualityProvider = (*fq)(nil)
+	_ core.EqualityProvider = (*rel)(nil)
+)
+
+const SymbolSep = "."
+
+// Symbol represents a lisp symbol Value.
+func Symbol(s string) core.Symbol {
+	if s = strings.TrimSpace(s); !isQualified(s) {
+		return rel(s)
+	}
+
+	return fq(strings.SplitN(strings.Trim(s, SymbolSep), SymbolSep, 2))
+}
+
+func isQualified(s string) bool {
+	// shortest valid fully-qualified symbol is ".x.y"
+	if len(s) < 4 || s[0] != '.' {
+		return false
+	}
+
+	// ".foo"
+	if strings.Count(s, SymbolSep) < 2 {
+		return false
+	}
+
+	return true
+}
+
+type fq []string
+
+func (s fq) String() string                              { return "." + strings.Join(s, SymbolSep) }
+func (s fq) Valid() bool                                 { return len(s) == 2 && s.Relative().Valid() }
+func (s fq) Namespace() core.Namespace                   { return core.Namespace(s[0]) }
+func (fq) Qualified() bool                               { return true }
+func (s fq) Relative() core.Symbol                       { return rel(s[1]) }
+func (s fq) WithNamespace(ns core.Namespace) core.Symbol { return fq{ns.String(), s[1]} }
+
+func (s fq) Equals(other core.Any) (bool, error) {
+	o, ok := other.(core.Symbol)
+	return ok && o.Valid() && s.String() == o.String(), nil
+}
+
+type rel string
+
+func (s rel) String() string                              { return string(s) }
+func (s rel) Valid() bool                                 { return len(s) > 0 }
+func (rel) Namespace() core.Namespace                     { panic("relative symbol") }
+func (rel) Qualified() bool                               { return false }
+func (s rel) Relative() core.Symbol                       { return s }
+func (s rel) WithNamespace(ns core.Namespace) core.Symbol { return fq{ns.String(), s.String()} }
+
+func (s rel) Equals(other core.Any) (bool, error) {
+	o, ok := other.(core.Symbol)
+	return ok && o.Valid() && string(s) == o.String(), nil
+}

--- a/builtin/value.go
+++ b/builtin/value.go
@@ -16,7 +16,6 @@ var (
 	_ core.Any = Bool(true)
 	_ core.Any = Char('∂')
 	_ core.Any = String("specimen")
-	_ core.Any = Symbol("specimen")
 	_ core.Any = Keyword("specimen")
 
 	_ core.Comparable = Int64(0)
@@ -26,7 +25,6 @@ var (
 	_ core.EqualityProvider = Bool(false)
 	_ core.EqualityProvider = Char('a')
 	_ core.EqualityProvider = String("specimen")
-	_ core.EqualityProvider = Symbol("specimen")
 	_ core.EqualityProvider = Keyword("specimen")
 )
 
@@ -142,20 +140,6 @@ func (str String) Equals(other core.Any) (bool, error) {
 }
 
 func (str String) String() string { return fmt.Sprintf("\"%s\"", string(str)) }
-
-// Symbol represents a lisp symbol Value.
-type Symbol string
-
-// SExpr returns a valid s-expression representing Symbol.
-func (sym Symbol) SExpr() (string, error) { return string(sym), nil }
-
-// Equals returns true if the other Value is also a symbol and has same Value.
-func (sym Symbol) Equals(other core.Any) (bool, error) {
-	otherSym, isSym := other.(Symbol)
-	return isSym && (sym == otherSym), nil
-}
-
-func (sym Symbol) String() string { return string(sym) }
 
 // Keyword represents a keyword Value.
 type Keyword string

--- a/builtin/vector_test.go
+++ b/builtin/vector_test.go
@@ -229,6 +229,7 @@ func TestPersistentVector(t *testing.T) {
 			i++
 			return false, nil
 		})
+		assert.NoError(t, err)
 	})
 }
 

--- a/core/core.go
+++ b/core/core.go
@@ -4,12 +4,7 @@ package core
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"sync"
 )
-
-const rootEnv = "<main>"
 
 var (
 	// ErrNotFound is returned by Env when a binding is not found
@@ -86,72 +81,6 @@ func Eval(env Env, analyzer Analyzer, form Any) (Any, error) {
 		return nil, err
 	}
 	return expr.Eval(env)
-}
-
-// New returns a root Env that can be used to execute forms.
-func New(globals map[string]Any) Env {
-	if globals == nil {
-		globals = map[string]Any{}
-	}
-	return &mapEnv{
-		parent: nil,
-		name:   rootEnv,
-		vars:   globals,
-	}
-}
-
-// mapEnv implements Env using a Go native map and RWMutex.
-type mapEnv struct {
-	parent Env
-	name   string
-	mu     sync.RWMutex
-	vars   map[string]Any
-}
-
-func (env *mapEnv) Name() string { return env.name }
-func (env *mapEnv) Parent() Env  { return env.parent }
-
-func (env *mapEnv) Child(name string, vars map[string]Any) Env {
-	if vars == nil {
-		vars = map[string]Any{}
-	}
-	return &mapEnv{
-		name:   name,
-		parent: env,
-		vars:   vars,
-	}
-}
-
-func (env *mapEnv) Bind(name string, val Any) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return fmt.Errorf("%w: %s", ErrInvalidName, name)
-	}
-
-	if env.parent == nil {
-		// only root env is shared between threads. so make sure
-		// concurrent accesses are synchronized.
-		env.mu.Lock()
-		defer env.mu.Unlock()
-	}
-
-	env.vars[name] = val
-	return nil
-}
-
-func (env *mapEnv) Resolve(name string) (Any, error) {
-	if env.parent == nil {
-		// only root env is shared between threads. so make sure
-		// concurrent accesses are synchronized.
-		env.mu.RLock()
-		defer env.mu.RUnlock()
-	}
-
-	v, found := env.vars[name]
-	if !found {
-		return nil, fmt.Errorf("%w: %s", ErrNotFound, name)
-	}
-	return v, nil
 }
 
 type constAnalyzer struct{}

--- a/core/core.go
+++ b/core/core.go
@@ -43,6 +43,13 @@ type Env interface {
 	Child(name string, vars map[string]Any) Env
 }
 
+// NamespaceProvider is an optional interface for Env, that
+// provides support for namespaces.
+type NamespaceProvider interface {
+	// Namespace returns the currently active namespace.
+	Namespace() string
+}
+
 // Analyzer implementation is responsible for performing syntax analysis
 // on given form.
 type Analyzer interface {

--- a/core/core.go
+++ b/core/core.go
@@ -21,28 +21,47 @@ type Env interface {
 	// Name returns the name of this env frame.
 	Name() string
 
+	// Namespace returns the active namespace.
+	Namespace() Namespace
+
 	// Parent returns the parent/outer env of this env. Returns nil
 	// if this env is the root.
 	Parent() Env
 
-	// Bind creates a local binding with given name and value.
-	Bind(name string, val Any) error
-
-	// Resolve resolves the symbol in this env and return its value
-	// if found. Returns ErrNotFound if name is not found in this
-	// env frame.
-	Resolve(name string) (Any, error)
+	// Scope of the current environment.
+	Scope() Scope
 
 	// Child returns a new env with given frame name and vars bound.
 	// Returned env will have this env as parent/outer.
 	Child(name string, vars map[string]Any) Env
+
+	// WithNamespace returns the named environment, creating it if it does
+	// not already exist.
+	WithNamespace(Namespace) Env
 }
 
-// NamespaceProvider is an optional interface for Env, that
-// provides support for namespaces.
-type NamespaceProvider interface {
-	// Namespace returns the currently active namespace.
-	Namespace() string
+// Scope is a named collection of variable bindings.
+type Scope interface {
+	// Bind creates a local binding with given name and value.
+	Bind(name Symbol, val Any) error
+
+	// Resolve resolves the symbol in this env and return its value
+	// if found. Returns ErrNotFound if name is not found in this
+	// env frame.
+	Resolve(name Symbol) (Any, error)
+}
+
+// Namespace is a string that defaults to "main" when empty.
+type Namespace string
+
+// String returns the namespace, substituting the empty string
+// for "main".
+func (ns Namespace) String() string {
+	if ns == "" {
+		return "main"
+	}
+
+	return string(ns)
 }
 
 // Analyzer implementation is responsible for performing syntax analysis

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -1,9 +1,12 @@
-package core
+package core_test
 
 import (
 	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/spy16/slurp/builtin"
+	"github.com/spy16/slurp/core"
 )
 
 var errUnknown = errors.New("failed")
@@ -13,29 +16,29 @@ func TestEval(t *testing.T) {
 
 	table := []struct {
 		title    string
-		form     Any
-		env      Env
-		analyzer Analyzer
-		want     Any
+		form     core.Any
+		env      core.Env
+		analyzer core.Analyzer
+		want     core.Any
 		wantErr  error
 	}{
 		{
 			title:    "WithNilAnalyzer",
-			env:      New(nil),
+			env:      builtin.NewEnv(nil),
 			analyzer: nil,
 			form:     100,
 			want:     100,
 		},
 		{
 			title:    "WithCustomAnalyzer",
-			env:      New(nil),
+			env:      builtin.NewEnv(nil),
 			analyzer: fakeAnalyzer{Res: "foo"},
 			form:     100,
 			want:     "foo",
 		},
 		{
 			title:    "WithAnalyzerError",
-			env:      New(nil),
+			env:      builtin.NewEnv(nil),
 			analyzer: fakeAnalyzer{Err: errUnknown},
 			form:     100,
 			want:     nil,
@@ -45,7 +48,7 @@ func TestEval(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			got, err := Eval(tt.env, tt.analyzer, tt.form)
+			got, err := core.Eval(tt.env, tt.analyzer, tt.form)
 			if tt.wantErr != nil {
 				assert(t, errors.Is(err, tt.wantErr),
 					"\nwantErr=%#v\ngot=%#v", tt.wantErr, got)
@@ -59,47 +62,11 @@ func TestEval(t *testing.T) {
 	}
 }
 
-func TestRoot(t *testing.T) {
-	env := New(nil)
-	child := env.Child("foo", nil)
-	got := Root(child)
-	assert(t, !reflect.DeepEqual(child, got), "expecting root, got child")
-	assert(t, reflect.DeepEqual(env, got), "returned env is not root")
-	assert(t, env.Name() == got.Name(), "want='%s', got='%s'", env.Name(), got.Name())
-}
-
-func Test_mapEnv_Bind_Resolve(t *testing.T) {
-	var v Any
-	var err error
-
-	env := New(map[string]Any{"foo": "bar"})
-
-	err = env.Bind("v", 1000)
-	assert(t, err == nil, "unexpected err: %+v", err)
-
-	err = env.Bind("", 1000)
-	assert(t, errors.Is(err, ErrInvalidName), "want ErrInvalidName, got '%+v'", err)
-
-	v, err = env.Resolve("foo")
-	assert(t, err == nil, "unexpected err: %+v", err)
-	assert(t, v == "bar", "want=%+v\ngot=%+v", "bar", v)
-
-	v, err = env.Resolve("non-existent")
-	assert(t, errors.Is(err, ErrNotFound), "want ErrNotFound, got '%+v'", err)
-	assert(t, v == nil, "want=nil, got=%+v", v)
-}
-
 type fakeAnalyzer struct {
-	Res Any
+	Res core.Any
 	Err error
 }
 
-func (fa fakeAnalyzer) Analyze(env Env, form Any) (Expr, error) {
-	return constExpr{Const: fa.Res}, fa.Err
-}
-
-func assert(t *testing.T, cond bool, msg string, args ...interface{}) {
-	if !cond {
-		t.Errorf(msg, args...)
-	}
+func (fa fakeAnalyzer) Analyze(env core.Env, form core.Any) (core.Expr, error) {
+	return builtin.ConstExpr{Const: fa.Res}, fa.Err
 }

--- a/core/core_test.go
+++ b/core/core_test.go
@@ -24,21 +24,21 @@ func TestEval(t *testing.T) {
 	}{
 		{
 			title:    "WithNilAnalyzer",
-			env:      builtin.NewEnv(nil),
+			env:      builtin.NewEnv(),
 			analyzer: nil,
 			form:     100,
 			want:     100,
 		},
 		{
 			title:    "WithCustomAnalyzer",
-			env:      builtin.NewEnv(nil),
+			env:      builtin.NewEnv(),
 			analyzer: fakeAnalyzer{Res: "foo"},
 			form:     100,
 			want:     "foo",
 		},
 		{
 			title:    "WithAnalyzerError",
-			env:      builtin.NewEnv(nil),
+			env:      builtin.NewEnv(),
 			analyzer: fakeAnalyzer{Err: errUnknown},
 			form:     100,
 			want:     nil,

--- a/core/error.go
+++ b/core/error.go
@@ -49,3 +49,7 @@ func (p Position) String() string {
 	}
 	return fmt.Sprintf("%s:%d:%d", p.File, p.Ln, p.Col)
 }
+
+type NamespaceInterrupt struct{ Env Env }
+
+func (NamespaceInterrupt) Error() string { return "namespace interrupt" }

--- a/core/error_test.go
+++ b/core/error_test.go
@@ -1,1 +1,0 @@
-package core

--- a/core/seq_test.go
+++ b/core/seq_test.go
@@ -1,1 +1,0 @@
-package core

--- a/core/symbol.go
+++ b/core/symbol.go
@@ -1,0 +1,28 @@
+package core
+
+type Symbol interface {
+	// String returns the symbol's resolution path.
+	String() string
+
+	// Namespace returns a valid namespace for a fully-qualified
+	// symbol.  If the symbol is not fully qualified, Namespace
+	// panics.
+	Namespace() Namespace
+
+	// Valid returns true if the symbol is valid.
+	Valid() bool
+
+	// Qualified returns true if the symbol's resolution
+	// path is fully-qualified.
+	Qualified() bool
+
+	// Relative returns a relative symbol.  If Qualified is
+	// true, the implementation should return an equivalent
+	// value.
+	Relative() Symbol
+
+	// WithNamespace returns a fully-qualified symbol with the
+	// supplied namespace.  If the symbol is fully-qualified,
+	// implementations should replace it with ns.
+	WithNamespace(ns Namespace) Symbol
+}

--- a/examples/conj/main.go
+++ b/examples/conj/main.go
@@ -63,7 +63,7 @@ func conj(vs ...core.Any) (core.Any, error) {
 }
 
 func main() {
-	env := core.New(globals)
+	env := builtin.NewEnv(globals)
 	eval := slurp.New(slurp.WithEnv(env))
 
 	r := repl.New(eval,

--- a/examples/conj/main.go
+++ b/examples/conj/main.go
@@ -63,7 +63,7 @@ func conj(vs ...core.Any) (core.Any, error) {
 }
 
 func main() {
-	env := builtin.NewEnv(globals)
+	env := builtin.NewEnv(builtin.WithNamespace("", globals))
 	eval := slurp.New(slurp.WithEnv(env))
 
 	r := repl.New(eval,

--- a/examples/conj/main.go
+++ b/examples/conj/main.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"log"
-	"os"
 	"reflect"
 
 	"github.com/spy16/slurp"
@@ -64,13 +63,10 @@ func conj(vs ...core.Any) (core.Any, error) {
 }
 
 func main() {
-	env := slurp.New()
-	if err := env.Bind(globals); err != nil {
-		fmt.Printf("bind failed: %+v\n", err)
-		os.Exit(1)
-	}
+	env := core.New(globals)
+	eval := slurp.New(slurp.WithEnv(env))
 
-	r := repl.New(env,
+	r := repl.New(eval,
 		repl.WithBanner("Welcome to slurp!\nTry typing '(conj [] 1)'."),
 		repl.WithPrompts(">>", " |"))
 

--- a/examples/rule-engine/main.go
+++ b/examples/rule-engine/main.go
@@ -41,7 +41,7 @@ func runDiscountingRule(rule string, user string) (bool, error) {
 		"current-user":        user,
 	}
 
-	env := core.New(globals)
+	env := builtin.NewEnv(globals)
 	eval := slurp.New(slurp.WithEnv(env))
 
 	shouldDiscount, err := eval.EvalStr(rule)

--- a/examples/rule-engine/main.go
+++ b/examples/rule-engine/main.go
@@ -41,9 +41,10 @@ func runDiscountingRule(rule string, user string) (bool, error) {
 		"current-user":        user,
 	}
 
-	ins := slurp.New()
-	_ = ins.Bind(globals)
-	shouldDiscount, err := ins.EvalStr(rule)
+	env := core.New(globals)
+	eval := slurp.New(slurp.WithEnv(env))
+
+	shouldDiscount, err := eval.EvalStr(rule)
 	return builtin.IsTruthy(shouldDiscount), err
 }
 

--- a/examples/rule-engine/main.go
+++ b/examples/rule-engine/main.go
@@ -41,7 +41,7 @@ func runDiscountingRule(rule string, user string) (bool, error) {
 		"current-user":        user,
 	}
 
-	env := builtin.NewEnv(globals)
+	env := builtin.NewEnv(builtin.WithNamespace("", globals))
 	eval := slurp.New(slurp.WithEnv(env))
 
 	shouldDiscount, err := eval.EvalStr(rule)

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -31,7 +31,7 @@ var globals = map[string]core.Any{
 }
 
 func main() {
-	env := core.New(globals)
+	env := builtin.NewEnv(globals)
 	eval := slurp.New(slurp.WithEnv(env))
 
 	r := repl.New(eval,

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -31,7 +31,7 @@ var globals = map[string]core.Any{
 }
 
 func main() {
-	env := builtin.NewEnv(globals)
+	env := builtin.NewEnv(builtin.WithNamespace("", globals))
 	eval := slurp.New(slurp.WithEnv(env))
 
 	r := repl.New(eval,

--- a/examples/simple/main.go
+++ b/examples/simple/main.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"log"
-	"os"
 
 	"github.com/spy16/slurp"
 	"github.com/spy16/slurp/builtin"
@@ -33,13 +31,10 @@ var globals = map[string]core.Any{
 }
 
 func main() {
-	env := slurp.New()
-	if err := env.Bind(globals); err != nil {
-		fmt.Printf("bind failed: %+v\n", err)
-		os.Exit(1)
-	}
+	env := core.New(globals)
+	eval := slurp.New(slurp.WithEnv(env))
 
-	r := repl.New(env,
+	r := repl.New(eval,
 		repl.WithBanner("Welcome to slurp!"),
 		repl.WithPrompts(">>", " |"))
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -15,7 +15,7 @@ import (
 // Evaluator implementation is responsible for executing givenn forms.
 type Evaluator interface {
 	Namespace() string
-	Eval(form core.Any) (core.Any, error)
+	Eval(forms ...core.Any) (core.Any, error)
 }
 
 // REPL implements a read-eval-print loop for a generic Runtime.

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -14,7 +14,7 @@ import (
 
 // Evaluator implementation is responsible for executing givenn forms.
 type Evaluator interface {
-	Namespace() string
+	CurrentNS() string
 	Eval(forms ...core.Any) (core.Any, error)
 }
 
@@ -151,7 +151,7 @@ func (repl *REPL) setPrompt(multiline bool) {
 		return
 	}
 
-	nsPrefix := repl.eval.Namespace()
+	nsPrefix := repl.eval.CurrentNS()
 	prompt := repl.prompt
 
 	if multiline {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -71,6 +71,7 @@ func (repl *REPL) readEvalPrint() error {
 	forms, err := repl.read()
 	if err != nil {
 		switch err.(type) {
+		case core.NamespaceInterrupt:
 		case reader.Error:
 			_ = repl.output.Print(err)
 		default:

--- a/slurp.go
+++ b/slurp.go
@@ -75,7 +75,7 @@ type Option func(eval *Evaluator)
 // env is nil, the default map-env will be used.
 func WithEnv(env core.Env) Option {
 	if env == nil {
-		env = core.New(nil)
+		env = builtin.NewEnv(nil)
 	}
 
 	ns, ok := env.(core.NamespaceProvider)

--- a/specials.go
+++ b/specials.go
@@ -367,6 +367,34 @@ func parseFnDef(a core.Analyzer, env core.Env, argSeq core.Seq) (*builtin.Fn, er
 }
 
 // parseNS
-func parseNS(a core.Analyzer, env core.Env, argSeq core.Seq) (core.Expr, error) {
-	panic("NOT IMPLEMENTED")
+func parseNS(a core.Analyzer, env core.Env, args core.Seq) (core.Expr, error) {
+	e := core.Error{Cause: fmt.Errorf("%w: ns", ErrParseSpecial)}
+	if args == nil {
+		return nil, e.With("requires exactly 2 args, got 0")
+	}
+	cnt, err := args.Count()
+	if err != nil {
+		return nil, err
+	}
+	if cnt != 1 {
+		return nil, e.With("requires exactly 1 arg, got 0")
+	}
+
+	any, err := args.First()
+	if err != nil {
+		return nil, err
+	}
+
+	sym, ok := any.(core.Symbol)
+	if !ok {
+		return nil, e.With(fmt.Sprintf("expected symbol, got %s", reflect.ValueOf(any)))
+	}
+
+	if !sym.Valid() || sym.Qualified() {
+		return nil, e.With(fmt.Sprintf("%s: %s", core.ErrInvalidName, sym))
+	}
+
+	return builtin.NamespaceExpr{
+		NS: core.Namespace(sym.String()),
+	}, nil
 }

--- a/specials.go
+++ b/specials.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/spy16/slurp/builtin"
 	"github.com/spy16/slurp/core"
@@ -106,7 +105,7 @@ func parseDef(a core.Analyzer, env core.Env, args core.Seq) (core.Expr, error) {
 		return nil, err
 	}
 
-	sym, ok := first.(builtin.Symbol)
+	sym, ok := first.(core.Symbol)
 	if !ok {
 		return nil, e.With(fmt.Sprintf(
 			"first arg must be symbol, not '%s'", reflect.TypeOf(first)))
@@ -128,7 +127,7 @@ func parseDef(a core.Analyzer, env core.Env, args core.Seq) (core.Expr, error) {
 	}
 
 	return builtin.DefExpr{
-		Name:  string(sym),
+		Name:  sym,
 		Value: res,
 	}, nil
 }
@@ -199,7 +198,7 @@ func parseLetBindings(a core.Analyzer, env core.Env, seq core.Seq, le *builtin.L
 	return core.ForEach(seq, func(item core.Any) (bool, error) {
 		// symbol?
 		if len(le.Names)%2 == 0 {
-			s, ok := item.(builtin.Symbol)
+			s, ok := item.(core.Symbol)
 			if !ok {
 				return false, core.Error{
 					Cause:   fmt.Errorf("%w: let", ErrParseSpecial),
@@ -207,7 +206,14 @@ func parseLetBindings(a core.Analyzer, env core.Env, seq core.Seq, le *builtin.L
 				}
 			}
 
-			le.Names = append(le.Names, string(s))
+			if s.Qualified() {
+				return false, core.Error{
+					Cause:   fmt.Errorf("%s: let", ErrParseSpecial),
+					Message: fmt.Sprintf("cannot bind fully-qualified symbol '%s' to local scope", s),
+				}
+			}
+
+			le.Names = append(le.Names, s.String())
 			return false, nil
 		}
 
@@ -288,8 +294,8 @@ func parseFnDef(a core.Analyzer, env core.Env, argSeq core.Seq) (*builtin.Fn, er
 	}
 
 	i := 0
-	if sym, ok := args[i].(builtin.Symbol); ok {
-		fn.Name = strings.TrimSpace(sym.String())
+	if sym, ok := args[i].(core.Symbol); ok {
+		fn.Name = sym.String()
 		i++
 	}
 
@@ -311,19 +317,28 @@ func parseFnDef(a core.Analyzer, env core.Env, argSeq core.Seq) (*builtin.Fn, er
 	fnEnv := env.Child(fn.Name, nil)
 	argSet := map[string]struct{}{}
 	err = core.ForEach(fnArgs, func(item core.Any) (bool, error) {
-		sym, ok := item.(builtin.Symbol)
+		sym, ok := item.(core.Symbol)
 		if !ok {
 			return true, fmt.Errorf(
 				"expecting parameter to be a symbol, got '%s'",
 				reflect.TypeOf(item))
 		}
-		if _, found := argSet[string(sym)]; found {
+
+		if sym.Qualified() {
+			return false, core.Error{
+				Cause:   ErrParseSpecial,
+				Message: fmt.Sprintf("cannot bind fully-qualified symbol '%s' to local scope", sym),
+			}
+		}
+
+		symName := sym.String()
+		if _, found := argSet[symName]; found {
 			return true, fmt.Errorf("duplicate arg name '%s'", sym)
 		}
-		argSet[string(sym)] = struct{}{}
-		f.Params = append(f.Params, string(sym))
+		argSet[symName] = struct{}{}
+		f.Params = append(f.Params, sym)
 
-		if err := fnEnv.Bind(string(sym), nil); err != nil {
+		if err := fnEnv.Scope().Bind(sym, nil); err != nil {
 			return false, err
 		}
 
@@ -349,4 +364,9 @@ func parseFnDef(a core.Analyzer, env core.Env, argSeq core.Seq) (*builtin.Fn, er
 	fn.Funcs = append(fn.Funcs, f)
 
 	return &fn, nil
+}
+
+// parseNS
+func parseNS(a core.Analyzer, env core.Env, argSeq core.Seq) (core.Expr, error) {
+	panic("NOT IMPLEMENTED")
 }

--- a/specials_test.go
+++ b/specials_test.go
@@ -16,19 +16,19 @@ func Test_parseFn(t *testing.T) {
 	table := []specialTest{
 		{
 			title:   "NilArgs",
-			env:     builtin.NewEnv(nil),
+			env:     builtin.NewEnv(),
 			args:    nil,
 			wantErr: errors.New("nil argument sequence"),
 		},
 		{
 			title:   "EmptyArgSeq",
-			env:     builtin.NewEnv(nil),
+			env:     builtin.NewEnv(),
 			args:    builtin.NewList(),
 			wantErr: core.ErrArity,
 		},
 		{
 			title: "Arity0_Fn",
-			env:   builtin.NewEnv(nil),
+			env:   builtin.NewEnv(),
 			args:  builtin.NewList(builtin.NewList()),
 			assert: func(t *testing.T, got core.Expr, err error) {
 				require.IsType(t, builtin.ConstExpr{}, got)
@@ -45,7 +45,7 @@ func Test_parseFn(t *testing.T) {
 		},
 		{
 			title: "Arity0_Fn_WithNameDoc",
-			env:   builtin.NewEnv(nil),
+			env:   builtin.NewEnv(),
 			args: builtin.NewList(
 				builtin.Symbol("foo"),
 				builtin.String("hello"),
@@ -66,7 +66,7 @@ func Test_parseFn(t *testing.T) {
 		},
 		{
 			title: "Arity0_Fn_WithArgs",
-			env:   builtin.NewEnv(nil),
+			env:   builtin.NewEnv(),
 			args: builtin.NewList(
 				builtin.Symbol("foo"),
 				builtin.NewList(builtin.Symbol("a"), builtin.Symbol("b")),
@@ -89,7 +89,7 @@ func Test_parseFn(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = builtin.NewEnv(nil)
+			tt.env = builtin.NewEnv()
 			runSpecialTest(t, tt, parseFn)
 		})
 	}
@@ -101,7 +101,7 @@ func Test_parseDo(t *testing.T) {
 	table := []specialTest{
 		{
 			title: "NilArgs",
-			env:   builtin.NewEnv(nil),
+			env:   builtin.NewEnv(),
 			args:  nil,
 			assert: func(t *testing.T, got core.Expr, err error) {
 				assert.Equal(t, got, builtin.DoExpr(nil))
@@ -109,7 +109,7 @@ func Test_parseDo(t *testing.T) {
 		},
 		{
 			title: "SomeArgs",
-			env:   builtin.NewEnv(nil),
+			env:   builtin.NewEnv(),
 			args:  builtin.NewList(1, 2),
 			assert: func(t *testing.T, got core.Expr, err error) {
 				want := builtin.DoExpr{
@@ -121,7 +121,7 @@ func Test_parseDo(t *testing.T) {
 		},
 		{
 			title:   "AnalyzeFail",
-			env:     builtin.NewEnv(nil),
+			env:     builtin.NewEnv(),
 			args:    builtin.NewList(1, builtin.NewList(builtin.Symbol("def"))),
 			wantErr: ErrParseSpecial,
 		},
@@ -153,7 +153,7 @@ func Test_parseDef(t *testing.T) {
 			args:  builtin.NewList(builtin.Symbol("foo"), 100),
 			assert: func(t *testing.T, got core.Expr, err error) {
 				want := builtin.DefExpr{
-					Name:  "foo",
+					Name:  builtin.Symbol("foo"),
 					Value: builtin.ConstExpr{Const: 100},
 				}
 				assert.Equal(t, want, got)
@@ -163,7 +163,7 @@ func Test_parseDef(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = builtin.NewEnv(nil)
+			tt.env = builtin.NewEnv()
 			runSpecialTest(t, tt, parseDef)
 		})
 	}
@@ -192,7 +192,7 @@ func Test_parseLet(t *testing.T) {
 				want := builtin.LetExpr{
 					Names:  []string{"x"},
 					Values: []core.Expr{builtin.ConstExpr{Const: builtin.Int64(42)}},
-					Exprs:  builtin.DoExpr{builtin.ResolveExpr{Symbol: "x"}},
+					Exprs:  builtin.DoExpr{builtin.ResolveExpr{Symbol: builtin.Symbol("x")}},
 				}
 
 				assert.Equal(t, want, got)
@@ -208,7 +208,7 @@ func Test_parseLet(t *testing.T) {
 				want := builtin.LetExpr{
 					Names:  []string{"x"},
 					Values: []core.Expr{builtin.ConstExpr{Const: builtin.Int64(42)}},
-					Exprs:  builtin.DoExpr{builtin.ResolveExpr{Symbol: "x"}},
+					Exprs:  builtin.DoExpr{builtin.ResolveExpr{Symbol: builtin.Symbol("x")}},
 				}
 
 				assert.Equal(t, want, got)
@@ -218,7 +218,7 @@ func Test_parseLet(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = builtin.NewEnv(nil)
+			tt.env = builtin.NewEnv()
 			runSpecialTest(t, tt, parseLet)
 		})
 	}

--- a/specials_test.go
+++ b/specials_test.go
@@ -16,19 +16,19 @@ func Test_parseFn(t *testing.T) {
 	table := []specialTest{
 		{
 			title:   "NilArgs",
-			env:     core.New(nil),
+			env:     builtin.NewEnv(nil),
 			args:    nil,
 			wantErr: errors.New("nil argument sequence"),
 		},
 		{
 			title:   "EmptyArgSeq",
-			env:     core.New(nil),
+			env:     builtin.NewEnv(nil),
 			args:    builtin.NewList(),
 			wantErr: core.ErrArity,
 		},
 		{
 			title: "Arity0_Fn",
-			env:   core.New(nil),
+			env:   builtin.NewEnv(nil),
 			args:  builtin.NewList(builtin.NewList()),
 			assert: func(t *testing.T, got core.Expr, err error) {
 				require.IsType(t, builtin.ConstExpr{}, got)
@@ -45,7 +45,7 @@ func Test_parseFn(t *testing.T) {
 		},
 		{
 			title: "Arity0_Fn_WithNameDoc",
-			env:   core.New(nil),
+			env:   builtin.NewEnv(nil),
 			args: builtin.NewList(
 				builtin.Symbol("foo"),
 				builtin.String("hello"),
@@ -66,7 +66,7 @@ func Test_parseFn(t *testing.T) {
 		},
 		{
 			title: "Arity0_Fn_WithArgs",
-			env:   core.New(nil),
+			env:   builtin.NewEnv(nil),
 			args: builtin.NewList(
 				builtin.Symbol("foo"),
 				builtin.NewList(builtin.Symbol("a"), builtin.Symbol("b")),
@@ -89,7 +89,7 @@ func Test_parseFn(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = core.New(nil)
+			tt.env = builtin.NewEnv(nil)
 			runSpecialTest(t, tt, parseFn)
 		})
 	}
@@ -101,7 +101,7 @@ func Test_parseDo(t *testing.T) {
 	table := []specialTest{
 		{
 			title: "NilArgs",
-			env:   core.New(nil),
+			env:   builtin.NewEnv(nil),
 			args:  nil,
 			assert: func(t *testing.T, got core.Expr, err error) {
 				assert.Equal(t, got, builtin.DoExpr(nil))
@@ -109,7 +109,7 @@ func Test_parseDo(t *testing.T) {
 		},
 		{
 			title: "SomeArgs",
-			env:   core.New(nil),
+			env:   builtin.NewEnv(nil),
 			args:  builtin.NewList(1, 2),
 			assert: func(t *testing.T, got core.Expr, err error) {
 				want := builtin.DoExpr{
@@ -121,7 +121,7 @@ func Test_parseDo(t *testing.T) {
 		},
 		{
 			title:   "AnalyzeFail",
-			env:     core.New(nil),
+			env:     builtin.NewEnv(nil),
 			args:    builtin.NewList(1, builtin.NewList(builtin.Symbol("def"))),
 			wantErr: ErrParseSpecial,
 		},
@@ -163,7 +163,7 @@ func Test_parseDef(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = core.New(nil)
+			tt.env = builtin.NewEnv(nil)
 			runSpecialTest(t, tt, parseDef)
 		})
 	}
@@ -218,7 +218,7 @@ func Test_parseLet(t *testing.T) {
 
 	for _, tt := range table {
 		t.Run(tt.title, func(t *testing.T) {
-			tt.env = core.New(nil)
+			tt.env = builtin.NewEnv(nil)
 			runSpecialTest(t, tt, parseLet)
 		})
 	}


### PR DESCRIPTION
@spy16 (cc @liefj)

This PR is a first attempt at implementing namespaces.  I've only done cursory testing because I wanted to get feedback as early as possible.

The high-level strategy is for the `NamespaceExpr` to return a special error called `NamespaceInterrupt`, which contains a pointer to the new global namespace.  The `Evaluator` catches `NamespaceInterrupt` and assigns the new env to itself.

On the env side of things, you will note significant changes to the `core.Env` interface.  From a semantic perspective, one creates new interfaces using a persistent interface embodied by `core.Env.WithNamespace`.  This has been implemented by splitting `mapEnv` into `builtin.Env` and `builtin.childEnv`.  The `builtin.Env` type is responsible for managing namespaces, and children are bound to the namespace of their parents.  Because the global scope of `builtin.Env` never changes, everything stays nice and consistent -- `childEnv`s will always see the same parent-namespace, even across `NamespaceInterrupt`s.

Please let me know your thoughts!  @spy16 If you feel this is mergeable, let me know, and I'll do so after writing a few more tests.

⏱️ Estimated review time:  1h.
❌  WIP. Do not merge.