### PR TITLE
Add formatters for built-in values

### DIFF
--- a/builtin/expr_test.go
+++ b/builtin/expr_test.go
@@ -91,7 +91,7 @@ func TestDefExpr_Eval(t *testing.T) {
 				return DefExpr{Name: "foo"}, core.New(nil)
 			},
 			want: Symbol("foo"),
-			assert: func(t *testing.T, got core.Any, err error, env core.Env) {
+			assert: func(t *testing.T, got core.Any, _ error, env core.Env) {
 				v, err := env.Resolve("foo")
 				assert.NoError(t, err)
 				assert.Equal(t, Nil{}, v)
@@ -116,7 +116,7 @@ func TestDefExpr_Eval(t *testing.T) {
 				}, core.New(nil)
 			},
 			want: Symbol("foo"),
-			assert: func(t *testing.T, got core.Any, err error, env core.Env) {
+			assert: func(t *testing.T, got core.Any, _ error, env core.Env) {
 				v, err := env.Resolve("foo")
 				assert.NoError(t, err)
 				assert.Equal(t, 10, v)

--- a/builtin/fn.go
+++ b/builtin/fn.go
@@ -108,12 +108,12 @@ func (f Func) matchArity(args []core.Any) bool {
 	return argc == len(f.Params)
 }
 
-func (f Func) minArity() int {
-	if len(f.Params) > 0 && f.Variadic {
-		return len(f.Params) - 1
-	}
-	return len(f.Params)
-}
+// func (f Func) minArity() int {
+// 	if len(f.Params) > 0 && f.Variadic {
+// 		return len(f.Params) - 1
+// 	}
+// 	return len(f.Params)
+// }
 
 func (f *Func) compare(other Func) (bool, error) {
 	if f.Variadic != other.Variadic ||

--- a/builtin/seq.go
+++ b/builtin/seq.go
@@ -49,14 +49,6 @@ type LinkedList struct {
 	rest  core.Seq
 }
 
-// SExpr returns a valid s-expression for LinkedList.
-func (ll *LinkedList) SExpr() (string, error) {
-	if ll == nil {
-		return "()", nil
-	}
-	return core.SeqString(ll, "(", ")", " ")
-}
-
 // Conj returns a new list with all the items added at the head of the list.
 func (ll *LinkedList) Conj(items ...core.Any) (res core.Seq, err error) {
 	res = ll

--- a/builtin/value.go
+++ b/builtin/value.go
@@ -33,9 +33,6 @@ var (
 // Nil represents the Value 'nil'.
 type Nil struct{}
 
-// SExpr returns a valid s-expression representing Nil.
-func (Nil) SExpr() (string, error) { return "nil", nil }
-
 // Equals returns true IFF other is nil.
 func (Nil) Equals(other core.Any) (bool, error) { return IsNil(other), nil }
 
@@ -43,9 +40,6 @@ func (Nil) String() string { return "nil" }
 
 // Int64 represents a 64-bit integer Value.
 type Int64 int64
-
-// SExpr returns a valid s-expression representing Int64.
-func (i64 Int64) SExpr() (string, error) { return i64.String(), nil }
 
 // Comp performs comparison against another Int64.
 func (i64 Int64) Comp(other core.Any) (int, error) {
@@ -67,9 +61,6 @@ func (i64 Int64) String() string { return strconv.Itoa(int(i64)) }
 
 // Float64 represents a 64-bit double precision floating point Value.
 type Float64 float64
-
-// SExpr returns a valid s-expression representing Float64.
-func (f64 Float64) SExpr() (string, error) { return f64.String(), nil }
 
 // Comp performs comparison against another Float64.
 func (f64 Float64) Comp(other core.Any) (int, error) {
@@ -97,9 +88,6 @@ func (f64 Float64) String() string {
 // Bool represents a boolean Value.
 type Bool bool
 
-// SExpr returns a valid s-expression representing Bool.
-func (b Bool) SExpr() (string, error) { return b.String(), nil }
-
 // Equals returns true if 'other' is a boolean and has same logical Value.
 func (b Bool) Equals(other core.Any) (bool, error) {
 	val, ok := other.(Bool)
@@ -116,11 +104,6 @@ func (b Bool) String() string {
 // Char represents a Unicode character.
 type Char rune
 
-// SExpr returns a valid s-expression representing Char.
-func (char Char) SExpr() (string, error) {
-	return fmt.Sprintf("\\%c", char), nil
-}
-
 // Equals returns true if the other Value is also a character and has same Value.
 func (char Char) Equals(other core.Any) (bool, error) {
 	val, isChar := other.(Char)
@@ -131,9 +114,6 @@ func (char Char) String() string { return fmt.Sprintf("\\%c", char) }
 
 // String represents a string of characters.
 type String string
-
-// SExpr returns a valid s-expression representing String.
-func (str String) SExpr() (string, error) { return str.String(), nil }
 
 // Equals returns true if 'other' is string and has same Value.
 func (str String) Equals(other core.Any) (bool, error) {
@@ -146,9 +126,6 @@ func (str String) String() string { return fmt.Sprintf("\"%s\"", string(str)) }
 // Symbol represents a lisp symbol Value.
 type Symbol string
 
-// SExpr returns a valid s-expression representing Symbol.
-func (sym Symbol) SExpr() (string, error) { return string(sym), nil }
-
 // Equals returns true if the other Value is also a symbol and has same Value.
 func (sym Symbol) Equals(other core.Any) (bool, error) {
 	otherSym, isSym := other.(Symbol)
@@ -159,9 +136,6 @@ func (sym Symbol) String() string { return string(sym) }
 
 // Keyword represents a keyword Value.
 type Keyword string
-
-// SExpr returns a valid s-expression representing Keyword.
-func (kw Keyword) SExpr() (string, error) { return kw.String(), nil }
 
 // Equals returns true if the other Value is keyword and has same Value.
 func (kw Keyword) Equals(other core.Any) (bool, error) {

--- a/builtin/value.go
+++ b/builtin/value.go
@@ -59,6 +59,21 @@ func (i64 Int64) Comp(other core.Any) (int, error) {
 
 func (i64 Int64) String() string { return strconv.Itoa(int(i64)) }
 
+func (i64 Int64) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'd':
+		fmt.Fprint(s, i64.String())
+
+	default:
+		if s.Flag('#') {
+			fmt.Fprintf(s, "%#v", int64(i64))
+			return
+		}
+
+		fmt.Fprintf(s, "%v", int64(i64))
+	}
+}
+
 // Float64 represents a 64-bit double precision floating point Value.
 type Float64 float64
 
@@ -79,10 +94,30 @@ func (f64 Float64) Comp(other core.Any) (int, error) {
 }
 
 func (f64 Float64) String() string {
-	if math.Abs(float64(f64)) >= 1e16 {
-		return fmt.Sprintf("%e", f64)
+	if f64 == 0 {
+		return "0."
 	}
-	return fmt.Sprintf("%f", f64)
+
+	if math.Abs(float64(f64)) >= 1e16 {
+		return fmt.Sprintf("%e", float64(f64))
+	}
+
+	return fmt.Sprintf("%f", float64(f64))
+}
+
+func (f64 Float64) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'f':
+		fmt.Fprint(s, f64.String())
+
+	default:
+		if s.Flag('#') {
+			fmt.Fprintf(s, "%#v", float64(f64))
+			return
+		}
+
+		fmt.Fprintf(s, "%v", float64(f64))
+	}
 }
 
 // Bool represents a boolean Value.

--- a/builtin/value.go
+++ b/builtin/value.go
@@ -156,7 +156,14 @@ func (str String) Equals(other core.Any) (bool, error) {
 	return isStr && (otherStr == str), nil
 }
 
-func (str String) String() string { return fmt.Sprintf("\"%s\"", string(str)) }
+func (str String) Format(s fmt.State, verb rune) {
+	if verb == 's' && s.Flag('#') {
+		fmt.Fprintf(s, "%s", string(str))
+		return
+	}
+
+	fmt.Fprintf(s, "%#v", string(str))
+}
 
 // Symbol represents a lisp symbol Value.
 type Symbol string

--- a/builtin/value_test.go
+++ b/builtin/value_test.go
@@ -2,6 +2,8 @@ package builtin_test
 
 import (
 	"errors"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/spy16/slurp/builtin"
@@ -43,6 +45,76 @@ func TestIsTruthy(t *testing.T) {
 	assert.True(t, builtin.IsTruthy(10))
 	assert.False(t, builtin.IsTruthy(nil))
 	assert.False(t, builtin.IsTruthy(false))
+}
+
+func TestFormat(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		any          core.Any
+		pretty, sxpr string
+	}{
+		{
+			any:    builtin.Nil{},
+			pretty: "nil",
+			sxpr:   "nil",
+		},
+		{
+			any:    builtin.Int64(0),
+			pretty: "0",
+			sxpr:   "0",
+		},
+		{
+			any:    builtin.Float64(0),
+			pretty: "0.",
+			sxpr:   "0.",
+		},
+		{
+			any:    builtin.Float64(1e16),
+			pretty: "1e16",
+			sxpr:   "1e16",
+		},
+		{
+			any:    builtin.Float64(-.2),
+			pretty: "-.2",
+			sxpr:   "-.2",
+		},
+		{
+			any:    builtin.Bool(false),
+			pretty: "false",
+			sxpr:   "false",
+		},
+		{
+			any:    builtin.Bool(true),
+			pretty: "true",
+			sxpr:   "true",
+		},
+		{
+			any:    builtin.Char('🧠'),
+			pretty: "\\🧠",
+			sxpr:   "\\🧠",
+		},
+		{
+			any:    builtin.String("foo"),
+			pretty: "\"foo\"",
+			sxpr:   "\"foo\"",
+		},
+		{
+			any:    builtin.Symbol("foo"),
+			pretty: "foo",
+			sxpr:   "foo",
+		},
+	} {
+		t.Run(reflect.TypeOf(tt.any).String(), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.pretty, fmt.Sprintf("%s", tt.any),
+				"invalid pretty-print output")
+
+			assert.Equal(t, tt.sxpr, fmt.Sprintf("%#s", tt.any),
+				"invalid symbolic expression")
+		})
+	}
 }
 
 func assertEq(t *testing.T, want, got core.Any, msgAndArgs ...interface{}) {

--- a/builtin/value_test.go
+++ b/builtin/value_test.go
@@ -1,52 +1,54 @@
-package builtin
+package builtin_test
 
 import (
 	"errors"
 	"testing"
 
+	"github.com/spy16/slurp/builtin"
 	"github.com/spy16/slurp/core"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNil(t *testing.T) {
-	n := Nil{}
+	n := builtin.Nil{}
 	assert.Equal(t, "nil", n.String())
-	testSExpr(t, n, "nil")
+	assertEq(t, builtin.Nil{}, n)
 }
 
 func TestInt64(t *testing.T) {
-	v := Int64(100)
+	v := builtin.Int64(100)
 	assert.Equal(t, "100", v.String())
-	testSExpr(t, v, "100")
+	assertEq(t, builtin.Int64(100), v)
 	testComp(t, v, 10, 0, core.ErrIncomparable)
 	testComp(t, v, v, 0, nil)
-	testComp(t, v, Int64(1), 1, nil)
-	testComp(t, v, Int64(10000), -1, nil)
+	testComp(t, v, builtin.Int64(1), 1, nil)
+	testComp(t, v, builtin.Int64(10000), -1, nil)
 }
 
 func TestFloat64(t *testing.T) {
-	assert.Equal(t, "1.000000e+19", Float64(1e19).String())
+	assert.Equal(t, "1.000000e+19", builtin.Float64(1e19).String())
 
-	v := Float64(100)
+	v := builtin.Float64(100)
 	assert.Equal(t, "100.000000", v.String())
-	testSExpr(t, v, "100.000000")
+	assertEq(t, builtin.Float64(100), v)
 	testComp(t, v, 10, 0, core.ErrIncomparable)
 	testComp(t, v, v, 0, nil)
-	testComp(t, v, Float64(1), 1, nil)
-	testComp(t, v, Float64(10000), -1, nil)
+	testComp(t, v, builtin.Float64(1), 1, nil)
+	testComp(t, v, builtin.Float64(10000), -1, nil)
 }
 
 func TestIsTruthy(t *testing.T) {
-	assert.True(t, IsTruthy(true))
-	assert.True(t, IsTruthy(10))
-	assert.False(t, IsTruthy(nil))
-	assert.False(t, IsTruthy(false))
+	assert.True(t, builtin.IsTruthy(true))
+	assert.True(t, builtin.IsTruthy(10))
+	assert.False(t, builtin.IsTruthy(nil))
+	assert.False(t, builtin.IsTruthy(false))
 }
 
-func testSExpr(t *testing.T, v core.SExpressable, want string) {
-	s, err := v.SExpr()
-	assert.NoError(t, err)
-	assert.Equal(t, want, s)
+func assertEq(t *testing.T, want, got core.Any, msgAndArgs ...interface{}) {
+	ok, err := core.Eq(want, got)
+	require.NoError(t, err, msgAndArgs...)
+	require.True(t, ok, msgAndArgs...)
 }
 
 func testComp(t *testing.T, v core.Comparable, other core.Any, want int, wantErr error) {

--- a/builtin/value_test.go
+++ b/builtin/value_test.go
@@ -104,6 +104,16 @@ func TestFormat(t *testing.T) {
 			pretty: "foo",
 			sxpr:   "foo",
 		},
+		{
+			any:    builtin.NewList(builtin.Keyword("foo")),
+			pretty: "(:foo)",
+			sxpr:   "(:foo)",
+		},
+		{
+			any:    builtin.NewVector(builtin.Keyword("foo")),
+			pretty: "[:foo]",
+			sxpr:   "[:foo]",
+		},
 	} {
 		t.Run(reflect.TypeOf(tt.any).String(), func(t *testing.T) {
 			assert.Equal(t, tt.sxpr, fmt.Sprintf("%s", tt.any),

--- a/builtin/value_test.go
+++ b/builtin/value_test.go
@@ -108,10 +108,10 @@ func TestFormat(t *testing.T) {
 		t.Run(reflect.TypeOf(tt.any).String(), func(t *testing.T) {
 			t.Parallel()
 
-			assert.Equal(t, tt.pretty, fmt.Sprintf("%s", tt.any),
+			assert.Equal(t, tt.pretty, fmt.Sprintf("%#s", tt.any),
 				"invalid pretty-print output")
 
-			assert.Equal(t, tt.sxpr, fmt.Sprintf("%#s", tt.any),
+			assert.Equal(t, tt.sxpr, fmt.Sprintf("%s", tt.any),
 				"invalid symbolic expression")
 		})
 	}

--- a/builtin/value_test.go
+++ b/builtin/value_test.go
@@ -66,18 +66,18 @@ func TestFormat(t *testing.T) {
 		},
 		{
 			any:    builtin.Float64(0),
-			pretty: "0.",
-			sxpr:   "0.",
+			pretty: "0",
+			sxpr:   "0",
 		},
 		{
 			any:    builtin.Float64(1e16),
-			pretty: "1e16",
-			sxpr:   "1e16",
+			pretty: "1e+16",
+			sxpr:   "1e+16",
 		},
 		{
 			any:    builtin.Float64(-.2),
-			pretty: "-.2",
-			sxpr:   "-.2",
+			pretty: "-0.2",
+			sxpr:   "-0.2",
 		},
 		{
 			any:    builtin.Bool(false),
@@ -96,7 +96,7 @@ func TestFormat(t *testing.T) {
 		},
 		{
 			any:    builtin.String("foo"),
-			pretty: "\"foo\"",
+			pretty: "foo",
 			sxpr:   "\"foo\"",
 		},
 		{
@@ -106,13 +106,11 @@ func TestFormat(t *testing.T) {
 		},
 	} {
 		t.Run(reflect.TypeOf(tt.any).String(), func(t *testing.T) {
-			t.Parallel()
+			assert.Equal(t, tt.sxpr, fmt.Sprintf("%s", tt.any),
+				"invalid symbolic expression")
 
 			assert.Equal(t, tt.pretty, fmt.Sprintf("%#s", tt.any),
 				"invalid pretty-print output")
-
-			assert.Equal(t, tt.sxpr, fmt.Sprintf("%s", tt.any),
-				"invalid symbolic expression")
 		})
 	}
 }

--- a/builtin/vector.go
+++ b/builtin/vector.go
@@ -76,16 +76,6 @@ func (v PersistentVector) Transient() *TransientVector {
 // Count returns the number of elements contained in the Vector.
 func (v PersistentVector) Count() (int, error) { return v.cnt, nil }
 
-// SExpr returns a parsable s-expression for the Vector.
-func (v PersistentVector) SExpr() (string, error) {
-	if v.cnt == 0 {
-		return "[]", nil
-	}
-
-	seq, _ := v.Seq()
-	return core.SeqString(seq, "[", "]", " ")
-}
-
 func (v PersistentVector) tailoff() int {
 	if v.cnt < width {
 		return 0
@@ -429,9 +419,6 @@ type TransientVector PersistentVector
 func (t TransientVector) Persistent() PersistentVector { return PersistentVector(t) }
 
 func (t TransientVector) tailoff() int { return PersistentVector(t).tailoff() }
-
-// SExpr returns an s-expression for the vector.
-func (t TransientVector) SExpr() (string, error) { return PersistentVector(t).SExpr() }
 
 // Count the number of elements in the vector.
 func (t TransientVector) Count() (int, error) { return t.cnt, nil }

--- a/builtin/vector_test.go
+++ b/builtin/vector_test.go
@@ -1,9 +1,10 @@
-package builtin
+package builtin_test
 
 import (
 	"fmt"
 	"testing"
 
+	"github.com/spy16/slurp/builtin"
 	"github.com/spy16/slurp/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,12 +21,12 @@ func TestVectorIsHashable(t *testing.T) {
 	}()
 
 	m := make(map[core.Vector]struct{})
-	m[EmptyVector] = struct{}{}
+	m[builtin.EmptyVector] = struct{}{}
 }
 
 func TestSeqToVector(t *testing.T) {
-	seq := NewList(Int64(0), Keyword("keyword"), String("string"))
-	v, err := SeqToVector(seq)
+	seq := builtin.NewList(builtin.Int64(0), builtin.Keyword("keyword"), builtin.String("string"))
+	v, err := builtin.SeqToVector(seq)
 	require.NoError(t, err)
 	require.NotNil(t, v)
 
@@ -43,15 +44,11 @@ func TestSeqToVector(t *testing.T) {
 func TestEmptyVector(t *testing.T) {
 	t.Parallel()
 
-	require.NotZero(t, EmptyVector,
+	require.NotZero(t, builtin.EmptyVector,
 		"zero-value empty vector is invalid (shift is missing)")
 
-	t.Run("SExpr", func(t *testing.T) {
-		testSExpr(t, EmptyVector, "[]")
-	})
-
 	t.Run("Seq", func(t *testing.T) {
-		seq, err := EmptyVector.Seq()
+		seq, err := builtin.EmptyVector.Seq()
 		assert.NoError(t, err)
 		assert.NotNil(t, seq)
 	})
@@ -59,16 +56,16 @@ func TestEmptyVector(t *testing.T) {
 	t.Run("Count", func(t *testing.T) {
 		t.Parallel()
 
-		cnt, err := EmptyVector.Count()
+		cnt, err := builtin.EmptyVector.Count()
 		assert.NoError(t, err)
-		assert.Zero(t, cnt, "EmptyVector has a non-zero count")
+		assert.Zero(t, cnt, "builtin.EmptyVector has a non-zero count")
 	})
 
 	t.Run("EntryAt", func(t *testing.T) {
 		t.Parallel()
 
-		v, err := EmptyVector.EntryAt(0)
-		assert.EqualError(t, err, ErrIndexOutOfBounds.Error())
+		v, err := builtin.EmptyVector.EntryAt(0)
+		assert.ErrorIs(t, err, builtin.ErrIndexOutOfBounds)
 		assert.Nil(t, v)
 	})
 
@@ -76,14 +73,14 @@ func TestEmptyVector(t *testing.T) {
 		t.Parallel()
 
 		t.Run("PersistentVector", func(t *testing.T) {
-			v, err := EmptyVector.Assoc(9001, Nil{})
-			assert.EqualError(t, err, ErrIndexOutOfBounds.Error())
+			v, err := builtin.EmptyVector.Assoc(9001, builtin.Nil{})
+			assert.ErrorIs(t, err, builtin.ErrIndexOutOfBounds)
 			assert.Nil(t, v)
 		})
 
 		t.Run("TransientVector", func(t *testing.T) {
-			v, err := EmptyVector.Transient().Assoc(9001, Nil{})
-			assert.EqualError(t, err, ErrIndexOutOfBounds.Error())
+			v, err := builtin.EmptyVector.Transient().Assoc(9001, builtin.Nil{})
+			assert.ErrorIs(t, err, builtin.ErrIndexOutOfBounds)
 			assert.Nil(t, v)
 		})
 	})
@@ -94,28 +91,21 @@ func TestPersistentVector(t *testing.T) {
 
 	as := make([]core.Any, size)
 	for i := 0; i < size; i++ {
-		as[i] = Int64(i)
+		as[i] = builtin.Int64(i)
 	}
-
-	t.Run("SExpr", func(t *testing.T) {
-		t.Parallel()
-
-		testSExpr(t, NewVector(Int64(0), Keyword("keyword"), String("string")),
-			"[0 :keyword \"string\"]")
-	})
 
 	t.Run("Conj", func(t *testing.T) {
 		t.Parallel()
 
 		t.Run("Nop", func(t *testing.T) {
-			v, err := EmptyVector.Conj()
+			v, err := builtin.EmptyVector.Conj()
 			require.NoError(t, err)
 			require.NotNil(t, v)
-			assert.Equal(t, EmptyVector, v)
+			assert.Equal(t, builtin.EmptyVector, v)
 		})
 
 		t.Run("PersistentConj", func(t *testing.T) {
-			v, err := EmptyVector.Conj(Nil{})
+			v, err := builtin.EmptyVector.Conj(builtin.Nil{})
 			require.NoError(t, err)
 			require.NotNil(t, v)
 
@@ -125,7 +115,7 @@ func TestPersistentVector(t *testing.T) {
 		})
 
 		t.Run("TransientConj", func(t *testing.T) {
-			v, err := EmptyVector.Conj(as...)
+			v, err := builtin.EmptyVector.Conj(as...)
 			require.NoError(t, err)
 			require.NotNil(t, v)
 
@@ -148,7 +138,7 @@ func TestPersistentVector(t *testing.T) {
 		t.Parallel()
 
 		var err error
-		var v core.Vector = EmptyVector
+		var v core.Vector = builtin.EmptyVector
 		for i, any := range as {
 			v, err = v.Assoc(i, any)
 			require.NoError(t, err, "Assoc() failed")
@@ -169,22 +159,22 @@ func TestPersistentVector(t *testing.T) {
 	t.Run("Replace", func(t *testing.T) {
 		t.Parallel()
 
-		v := NewVector(as...)
+		v := builtin.NewVector(as...)
 		for i := range as {
-			vPrime, err := v.Assoc(i, Nil{})
+			vPrime, err := v.Assoc(i, builtin.Nil{})
 			assert.NoError(t, err)
 			assert.NotNil(t, vPrime)
 
 			val, err := vPrime.EntryAt(i)
 			assert.NoError(t, err)
-			assert.Equal(t, Nil{}, val)
+			assert.Equal(t, builtin.Nil{}, val)
 		}
 	})
 
 	t.Run("Pop", func(t *testing.T) {
 		t.Parallel()
 
-		var v core.Vector = NewVector(as...)
+		var v core.Vector = builtin.NewVector(as...)
 
 		cnt, err := v.Count()
 		require.NoError(t, err, "test precondition failed")
@@ -206,7 +196,7 @@ func TestPersistentVector(t *testing.T) {
 	})
 
 	t.Run("Seq", func(t *testing.T) {
-		seq, err := EmptyVector.Seq()
+		seq, err := builtin.EmptyVector.Seq()
 		require.NoError(t, err)
 		require.NotNil(t, seq)
 
@@ -229,6 +219,7 @@ func TestPersistentVector(t *testing.T) {
 			i++
 			return false, nil
 		})
+		require.NoError(t, err)
 	})
 }
 
@@ -237,13 +228,13 @@ func TestTransientVector(t *testing.T) {
 
 	as := make([]core.Any, size)
 	for i := 0; i < size; i++ {
-		as[i] = Int64(i)
+		as[i] = builtin.Int64(i)
 	}
 
 	t.Run("NewTransientVector", func(t *testing.T) {
 		t.Parallel()
 
-		v := NewVector(as...).Transient()
+		v := builtin.NewVector(as...).Transient()
 		assert.NotNil(t, v)
 
 		cnt, err := v.Count()
@@ -252,17 +243,10 @@ func TestTransientVector(t *testing.T) {
 
 	})
 
-	t.Run("SExpr", func(t *testing.T) {
-		t.Parallel()
-
-		vec := NewVector(Int64(0), Keyword("keyword"), String("string")).Transient()
-		testSExpr(t, vec, "[0 :keyword \"string\"]")
-	})
-
 	t.Run("Count", func(t *testing.T) {
 		t.Parallel()
 
-		v := NewVector(as...).Transient()
+		v := builtin.NewVector(as...).Transient()
 
 		cnt, err := v.Count()
 		assert.NoError(t, err)
@@ -272,7 +256,7 @@ func TestTransientVector(t *testing.T) {
 	t.Run("Conj", func(t *testing.T) {
 		t.Parallel()
 
-		v, err := EmptyVector.Transient().Conj(as...)
+		v, err := builtin.EmptyVector.Transient().Conj(as...)
 		require.NoError(t, err)
 		require.NotNil(t, v)
 
@@ -292,23 +276,23 @@ func TestTransientVector(t *testing.T) {
 	t.Run("Append", func(t *testing.T) {
 		t.Parallel()
 
-		v := EmptyVector.Transient()
+		v := builtin.EmptyVector.Transient()
 
 		for i := 0; i < size; i++ {
-			vPrime, err := v.Assoc(i, Int64(i))
+			vPrime, err := v.Assoc(i, builtin.Int64(i))
 			require.NoError(t, err, "Assoc() failed")
 			require.NotNil(t, vPrime, "Assoc() returned a nil vector")
 
 			val, err := v.EntryAt(i)
 			require.NoError(t, err, "EntryAt() failed")
 			require.NotNil(t, val, "EntryAt() returned a nil value")
-			require.Equal(t, Int64(i), val,
+			require.Equal(t, builtin.Int64(i), val,
 				"value recovered does not match associated value")
 
 			val, err = vPrime.EntryAt(i)
 			require.NoError(t, err, "EntryAt() failed")
 			require.NotNil(t, val, "EntryAt() returned a nil value")
-			require.Equal(t, Int64(i), val,
+			require.Equal(t, builtin.Int64(i), val,
 				"value recovered does not match associated value")
 
 			cnt, err := v.Count()
@@ -324,26 +308,26 @@ func TestTransientVector(t *testing.T) {
 	t.Run("Replace", func(t *testing.T) {
 		t.Parallel()
 
-		var v core.Vector = NewVector(as...).Transient()
+		var v core.Vector = builtin.NewVector(as...).Transient()
 		for i := range as {
-			vPrime, err := v.Assoc(i, Nil{})
+			vPrime, err := v.Assoc(i, builtin.Nil{})
 			assert.NoError(t, err)
 			assert.NotNil(t, vPrime)
 
 			val, err := v.EntryAt(i)
 			assert.NoError(t, err)
-			assert.Equal(t, Nil{}, val)
+			assert.Equal(t, builtin.Nil{}, val)
 
 			val, err = vPrime.EntryAt(i)
 			assert.NoError(t, err)
-			assert.Equal(t, Nil{}, val)
+			assert.Equal(t, builtin.Nil{}, val)
 		}
 	})
 
 	t.Run("Pop", func(t *testing.T) {
 		t.Parallel()
 
-		var v core.Vector = NewVector(as...).Transient()
+		var v core.Vector = builtin.NewVector(as...).Transient()
 
 		cnt, err := v.Count()
 		require.NoError(t, err, "test precondition failed")
@@ -369,7 +353,7 @@ func TestTransientVector(t *testing.T) {
 	})
 
 	t.Run("Seq", func(t *testing.T) {
-		v := NewVector(as...).Transient()
+		v := builtin.NewVector(as...).Transient()
 		seq, err := v.Seq()
 		require.NoError(t, err)
 
@@ -394,14 +378,14 @@ func TestTransientVector(t *testing.T) {
 	t.Run("Invariants", func(t *testing.T) {
 		t.Parallel()
 
-		v := EmptyVector.Transient()
-		v.Conj(Nil{})
+		v := builtin.EmptyVector.Transient()
+		v.Conj(builtin.Nil{})
 
-		assert.NotEqual(t, EmptyVector, v,
-			"derived transient mutated EmptyVector")
+		assert.NotEqual(t, builtin.EmptyVector, v,
+			"derived transient mutated builtin.EmptyVector")
 
-		assert.Equal(t, EmptyVector, EmptyVector.Transient().Persistent(),
-			"persistent() ∘ Transient() ∘ persistent() ∘ EmptyVector != EmptyVector")
+		assert.Equal(t, builtin.EmptyVector, builtin.EmptyVector.Transient().Persistent(),
+			"persistent() ∘ Transient() ∘ persistent() ∘ builtin.EmptyVector != builtin.EmptyVector")
 	})
 }
 
@@ -442,14 +426,14 @@ type benchSuite interface {
 
 type persistentUnoptimized struct{ vec core.Vector }
 
-func (suite *persistentUnoptimized) Setup(b *testing.B) { suite.vec = EmptyVector }
+func (suite *persistentUnoptimized) Setup(b *testing.B) { suite.vec = builtin.EmptyVector }
 
 func (suite *persistentUnoptimized) Teardown() {}
 
 func (suite *persistentUnoptimized) BenchmarkConj(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// call Conj() one item at a time to avoid triggering transient optimization.
-		suite.vec, _ = suite.vec.Conj(Int64(i))
+		suite.vec, _ = suite.vec.Conj(builtin.Int64(i))
 	}
 }
 
@@ -459,11 +443,11 @@ type persistentOptimized struct {
 }
 
 func (suite *persistentOptimized) Setup(b *testing.B) {
-	suite.vec = EmptyVector
+	suite.vec = builtin.EmptyVector
 
 	suite.items = make([]core.Any, b.N)
 	for i := 0; i < b.N; i++ {
-		suite.items[i] = Int64(i)
+		suite.items[i] = builtin.Int64(i)
 	}
 }
 
@@ -476,7 +460,7 @@ func (suite *persistentOptimized) BenchmarkConj(b *testing.B) {
 type transientUnbatched struct{ vec core.Vector }
 
 func (suite *transientUnbatched) Setup(b *testing.B) {
-	suite.vec = EmptyVector.Transient()
+	suite.vec = builtin.EmptyVector.Transient()
 }
 
 func (suite *transientUnbatched) Teardown() {}
@@ -484,7 +468,7 @@ func (suite *transientUnbatched) Teardown() {}
 func (suite *transientUnbatched) BenchmarkConj(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// call Conj() one item at a time to avoid triggering transient optimization.
-		suite.vec, _ = suite.vec.Conj(Int64(i))
+		suite.vec, _ = suite.vec.Conj(builtin.Int64(i))
 	}
 }
 
@@ -494,11 +478,11 @@ type transientBatched struct {
 }
 
 func (suite *transientBatched) Setup(b *testing.B) {
-	suite.vec = EmptyVector.Transient()
+	suite.vec = builtin.EmptyVector.Transient()
 
 	suite.items = make([]core.Any, b.N)
 	for i := 0; i < b.N; i++ {
-		suite.items[i] = Int64(i)
+		suite.items[i] = builtin.Int64(i)
 	}
 }
 

--- a/core/seq.go
+++ b/core/seq.go
@@ -65,17 +65,7 @@ func SeqString(seq Seq, begin, end, sep string) (string, error) {
 	var b strings.Builder
 	b.WriteString(begin)
 	err := ForEach(seq, func(item Any) (bool, error) {
-		if se, ok := item.(SExpressable); ok {
-			s, err := se.SExpr()
-			if err != nil {
-				return false, err
-			}
-			b.WriteString(s)
-
-		} else {
-			b.WriteString(fmt.Sprintf("%v", item))
-		}
-
+		b.WriteString(fmt.Sprintf("%v", item))
 		b.WriteString(sep)
 		return false, nil
 	})

--- a/core/value.go
+++ b/core/value.go
@@ -27,13 +27,6 @@ type Invokable interface {
 	Invoke(args ...Any) (Any, error)
 }
 
-// SExpressable forms can be rendered as s-expressions.
-type SExpressable interface {
-	// SExpr returns a parsable s-expression of the given value. Returns
-	// error if not possible.
-	SExpr() (string, error)
-}
-
 // Comparable values define a partial ordering.
 type Comparable interface {
 	// Comp(pare) the value to another value.  Returns:

--- a/core/value_test.go
+++ b/core/value_test.go
@@ -1,11 +1,11 @@
 package core_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/spy16/slurp/builtin"
 	"github.com/spy16/slurp/core"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCompare(t *testing.T) {
@@ -55,12 +55,11 @@ func TestCompare(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			got, err := core.Compare(tt.a, tt.b)
 			if tt.wantErr != nil {
-				assert(t, errors.Is(err, tt.wantErr),
-					"wantErr=%#v\ngot=%#v", tt.wantErr, err)
-				assert(t, got == 0, "want=0 got=%d", got)
+				assert.ErrorIs(t, err, tt.wantErr)
+				assert.Zero(t, got)
 			} else {
-				assert(t, err == nil, "unexpected error: %#v", err)
-				assert(t, tt.want == got, "want=%d got=%d", tt.want, got)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
 			}
 		})
 	}
@@ -123,12 +122,11 @@ func TestEq(t *testing.T) {
 		t.Run(tt.title, func(t *testing.T) {
 			got, err := core.Eq(tt.a, tt.b)
 			if tt.wantErr != nil {
-				assert(t, errors.Is(tt.wantErr, err),
-					"wantErr=%#v\ngotErr=%#v", tt.wantErr, err)
+				assert.ErrorIs(t, err, tt.wantErr)
 			} else {
-				assert(t, err == nil, "unexpected err: %#v", err)
+				assert.NoError(t, err)
 			}
-			assert(t, tt.want == got, "want=%t, got=%t", tt.want, got)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }
@@ -167,8 +165,8 @@ func (fc fakeComparable) Comp(other core.Any) (int, error) {
 	}
 }
 
-func assert(t *testing.T, cond bool, msg string, args ...interface{}) {
-	if !cond {
-		t.Errorf(msg, args...)
-	}
-}
+// func assert(t *testing.T, cond bool, msg string, args ...interface{}) {
+// 	if !cond {
+// 		t.Errorf(msg, args...)
+// 	}
+// }

--- a/repl/printer.go
+++ b/repl/printer.go
@@ -45,7 +45,9 @@ func (r *Renderer) Print(val interface{}) (err error) {
 	case error:
 		_, err = fmt.Fprintf(r.Err, "%#s\n", val)
 	default:
-		_, err = fmt.Fprintf(r.Out, "%#s\n", val)
+		// Values should be represented as an s-expression
+		// to avoid ambiguity between similar values (e.g. symbol vs string)
+		_, err = fmt.Fprintf(r.Out, "%s\n", val)
 	}
 
 	return


### PR DESCRIPTION
In the spirit of #16, this PR adds formatting options for built-in values.

By convention:

- `%s` returns an s-expression
- `%#s` returns a human-readable representation

I considered inverting the two, but wanted to stay consistent with error formatting, where `#` means "pretty".

⏱️ Estimated review time:  15 min.
❌ WIP. Do not merge.