### PR TITLE
fix inaccurate line numbers

### DIFF
--- a/reader/reader.go
+++ b/reader/reader.go
@@ -274,7 +274,7 @@ func (rd *Reader) Token(init rune) (string, error) {
 
 // Container reads multiple forms until 'end' rune is reached. Should be used to read
 // collection types like List etc. formType is only used to annotate errors.
-func (rd Reader) Container(end rune, formType string, f func(core.Any) error) error {
+func (rd *Reader) Container(end rune, formType string, f func(core.Any) error) error {
 	for {
 		if err := rd.SkipSpaces(); err != nil {
 			if err == io.EOF {


### PR DESCRIPTION
Hi there!

This is a really cool package. I'm working on a new Lisp and it'd be great to use this package along the way.

I noticed line numbers in error messages seemed way off in a couple experiments, and finally tracked it down to a missing `*`.

I don't see any tests that cover error locations - happy to write one, just submitting this before I forget to.